### PR TITLE
Bug fix for issue #24

### DIFF
--- a/blinky-statik/src/main/java/org/spideruci/analysis/statik/UnitIdTag.java
+++ b/blinky-statik/src/main/java/org/spideruci/analysis/statik/UnitIdTag.java
@@ -1,0 +1,30 @@
+package org.spideruci.analysis.statik;
+
+import soot.tagkit.AttributeValueException;
+import soot.tagkit.Tag;
+
+public class UnitIdTag implements Tag {
+  
+  public static final String UNIT_ID_TAG_NAME = "UNIT_ID_TAG";
+  
+  private final String value;
+  
+  public UnitIdTag(final String id) {
+    value = id;
+  }
+
+  @Override
+  public String getName() {
+    return UNIT_ID_TAG_NAME;
+  }
+
+  @Override
+  public byte[] getValue() throws AttributeValueException {
+    return value.getBytes();
+  }
+  
+  public String value() {
+    return value;
+  }
+
+}

--- a/blinky-statik/src/main/java/org/spideruci/analysis/statik/flow/StatikFlowGraph.java
+++ b/blinky-statik/src/main/java/org/spideruci/analysis/statik/flow/StatikFlowGraph.java
@@ -11,6 +11,7 @@ import org.spideruci.analysis.statik.controlflow.Graph;
 
 import soot.Body;
 import soot.MethodOrMethodContext;
+import soot.PatchingChain;
 import soot.Scene;
 import soot.SootMethod;
 import soot.Unit;
@@ -108,11 +109,11 @@ public class StatikFlowGraph {
     int i = 0;
     
     while(!worklist.isEmpty()) {
-    	
-    	if(i%10 == 0)
-    		System.out.println("building.....");
-    	i++;
-    	
+
+      if(i%10 == 0)
+        System.out.println("building.....");
+      i++;
+
       SootMethod srcMethod = worklist.remove(0);
       if(methodIsInvalid(srcMethod)) {
         continue;
@@ -131,9 +132,9 @@ public class StatikFlowGraph {
         Body tgtBody = tgtMethod.retrieveActiveBody();
         
         Unit callUnit = edge.srcUnit();
-        Unit entryUnit = tgtBody.getUnits().getFirst();
-        int tgtStartLine = tgtMethod.getJavaSourceStartLineNumber();
-        entryUnit.addTag(new LineNumberTag(tgtStartLine));
+        Unit entryUnit = getEntryUnit(tgtBody);
+//        int tgtStartLine = tgtMethod.getJavaSourceStartLineNumber();
+//        entryUnit.addTag(new LineNumberTag(tgtStartLine));
         
         List<Unit> tgtExitUnits = SootCommander.GET_UNIT_GRAPH(tgtMethod).getTails();
         
@@ -150,6 +151,17 @@ public class StatikFlowGraph {
     }
     
   }
+  
+    private Unit getEntryUnit(Body body) {
+      PatchingChain<Unit> units = body.getUnits();
+      
+      for(Unit unit : units) {
+        if(unit.getJavaSourceStartLineNumber() > 0)
+          return unit;
+      }
+      
+      return units.getFirst();
+    }
   
     private boolean methodIsInvalid(SootMethod method) {
       return method == null || !method.isConcrete();


### PR DESCRIPTION
What: Blinky Statik: ICFG: Missing edges bw. call site and method

Details:
This was a multi-faceted issue:
1. The edges from the call-site to the method's first line were missing.
2. The edges from the method's return statement, particulaly for void
returns to the method's call site was missing.

Reasons:
1. For the first issue: the call-site-to-method edges were missing
because the first Jimple statement in a SootMethod's body did not have
a source code line number and so the Source ICFG would ignore such
nodes and any related edges.
2. For the second issue: the labels being created for Soot-based Units
that were also to be used as the Units' identifiers in the ICFG were
based on the Unit's string repr. This created conflicts because two
different Soot Units that represent two different instructions can
have the same string repr, eg. two void returns for two different
methods will both have the string `return` as their string repr.

Fixes:
1. For the first issue: we are now picking up the first Unit in a
SootMethod with an actual, valid Java source line number. This ensures
that there are no Units with an invalid source line number in the
Jimple based ICFG.
2. For the second issue: we are now using a Unit's source line number,
string repr(esentation) and the Unit's method's string repr. This should
reliably provide unique labels for Units. It would be better to use the
bytecode offset for such labels but that is not part of this fix and is
tracked by issue #27