### PR TITLE
Blinky Statik: Call Graph Management with Dedicated API

### DIFF
--- a/blinky-statik/src/main/java/org/spideruci/analysis/statik/AnalysisConfig.java
+++ b/blinky-statik/src/main/java/org/spideruci/analysis/statik/AnalysisConfig.java
@@ -15,6 +15,7 @@ public class AnalysisConfig {
   public final static String ARG_CLASS = "argclass";
   public final static String ENTRY_CLASS = "entryclass";
   public final static String ENTRY_METHOD = "entrymethod";
+  public final static String DEBUG = "debug";
   
   // Add new configuration file keys above here.
   

--- a/blinky-statik/src/main/java/org/spideruci/analysis/statik/SootCommander.java
+++ b/blinky-statik/src/main/java/org/spideruci/analysis/statik/SootCommander.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import soot.Body;
 import soot.Scene;
+import soot.SootClass;
 import soot.SootMethod;
 import soot.jimple.toolkits.callgraph.CallGraph;
 import soot.toolkits.graph.ExceptionalUnitGraph;
@@ -37,6 +38,14 @@ public class SootCommander {
   
   public static CallGraph GET_CALLGRAPH() {
     return Scene.v().getCallGraph();
+  }
+  
+  public static SootClass GET_MAIN_CLASS() {
+    return Scene.v().getMainClass();
+  }
+  
+  public static SootMethod GET_MAIN_METHOD() {
+    return Scene.v().getMainMethod();
   }
 
 }

--- a/blinky-statik/src/main/java/org/spideruci/analysis/statik/Statik.java
+++ b/blinky-statik/src/main/java/org/spideruci/analysis/statik/Statik.java
@@ -55,7 +55,7 @@ public class Statik {
     
     List<String> argsList = new ArrayList<>();
     argsList.addAll(Arrays.asList(new String[] {
-        "--keep-line-number",
+        "-keep-line-number",
         "-cp",
         jre7path + "/rt.jar:" + jre7path + "/jce.jar:" + "./target/test-classes/",
 //        ".:" + jre7path + "/rt.jar:" + jre7path + "/jce.jar:" + "/Users/Ku/Documents/uci/research/joda-time/target/joda-time-2.9.4-jar-with-dependencies.jar:" + "/Users/Ku/Documents/uci/research/blinky/blinky-statik/target/test-classes",
@@ -73,7 +73,7 @@ public class Statik {
     DummyMainManager.setupDummyMain();
     
     StatikCallGraphBuilder cgBuilder = 
-        StatikCallGraphBuilder.build("call-graph", analysisconfig.getArgs());
+        StatikCallGraphBuilder.build("call-graph", analysisconfig);
     
     cgBuilder.addEntryPoint(
         analysisconfig.get(AnalysisConfig.ENTRY_CLASS), 

--- a/blinky-statik/src/main/java/org/spideruci/analysis/statik/calls/CallGraphManager.java
+++ b/blinky-statik/src/main/java/org/spideruci/analysis/statik/calls/CallGraphManager.java
@@ -1,0 +1,233 @@
+package org.spideruci.analysis.statik.calls;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+
+import org.spideruci.analysis.statik.DebugUtil;
+import org.spideruci.analysis.statik.Items;
+import org.spideruci.analysis.statik.controlflow.Algorithms;
+import org.spideruci.analysis.statik.controlflow.Graph;
+import org.spideruci.analysis.statik.controlflow.Node;
+import org.spideruci.analysis.util.MyAssert;
+
+import soot.Scene;
+import soot.SootMethod;
+import soot.Unit;
+import soot.jimple.toolkits.callgraph.CallGraph;
+import soot.jimple.toolkits.callgraph.Edge;
+
+public class CallGraphManager {
+  
+  private CallGraph callgraph;
+  private Graph<SootMethod> shadowCallgraph;
+  private ArrayList<SootMethod> entryPoints;
+  
+  /**
+   * Initializes a static inter-proc flow graph, without using the main method
+   * as an entry point.
+   * @param cg
+   * @param entryMethods
+   * @return
+   */
+  public static CallGraphManager init(CallGraph cg, List<SootMethod> entryMethods) {
+    return init(cg, entryMethods, false);
+  }
+  
+  public static CallGraphManager init(CallGraph cg, 
+      List<SootMethod> entryMethods, 
+      boolean useMainAsEntry) {
+    
+    CallGraphManager cgm = new CallGraphManager(cg);
+    cgm.makeShadowGraph();
+
+    for(SootMethod method : entryMethods) {
+      cgm.addEntryPoint(method);
+    }
+   
+    if(useMainAsEntry) {
+      SootMethod main = Scene.v().getMainClass().getMethodByName("main");
+      cgm.addEntryPoint(main);
+    }
+
+    return cgm;
+  }
+  
+    private CallGraphManager(CallGraph cg) {
+      this.callgraph = cg;
+      this.entryPoints = new ArrayList<>();
+      this.shadowCallgraph = Graph.create();
+    }
+
+  public CallGraph getCallgraph() {
+    return this.callgraph;
+  }
+  
+  public ArrayList<SootMethod> getEntryPoints() {
+    return this.entryPoints;
+  }
+    
+  public void addEntryPoint(SootMethod method) {
+    entryPoints.add(method);
+    Node<SootMethod> node = getShadowMethod(method);
+    this.shadowCallgraph.startPointsTo(node);
+  }
+  
+  public boolean methodExists(SootMethod method) {
+    final Node<SootMethod> node = getShadowMethod(method);
+    final boolean methodExists = node != null;
+
+    if(methodExists)
+      MyAssert.assertThat(method.equivHashCode() == node.getBody().equivHashCode());
+    
+    return methodExists;
+  }
+
+  public Iterable<SootMethod> getMethodCallers(SootMethod method) {
+    
+    if(methodExists(method)) {
+      final Node<SootMethod> node = getShadowMethod(method);
+      ArrayList<Node<SootMethod>> shadowCallers = node.getPredecessors();
+      Iterable<SootMethod> callers = fromShadowMethods(shadowCallers);
+      return callers;
+    }
+    
+    return Collections.emptyList();
+  }
+  
+  public Iterable<SootMethod> getMethodCallsFrom(SootMethod method) {
+    
+    if(methodExists(method)) {
+      final Node<SootMethod> node = getShadowMethod(method);
+      ArrayList<Node<SootMethod>> shadowCallers = node.pointsTo();
+      Iterable<SootMethod> callers = fromShadowMethods(shadowCallers);
+      return callers;
+    }
+    
+    return Collections.emptyList();
+  }
+  
+  public HashMap<Node<SootMethod>, Node<SootMethod>> getStrongComponents() {
+    return Algorithms.getStronglyConnectedComponents(shadowCallgraph);
+  }
+  
+  public Iterable<SootMethod> getBottomupTopology() {
+    Algorithms.collapseStrongComponents(shadowCallgraph);
+    
+    ArrayList<Node<SootMethod>> topology = 
+        Algorithms.bottomUpTopologicalSort(shadowCallgraph);
+    Iterable<SootMethod> methodTopology = fromShadowMethods(topology);
+    
+    makeShadowGraph();
+    
+    return methodTopology;
+  }
+  
+  public Iterable<SootMethod> getDfsTraversal() {
+    ArrayList<Node<SootMethod>> traversal = Algorithms.traverseDfs(shadowCallgraph);
+    Iterable<SootMethod> methods = fromShadowMethods(traversal);
+    return methods;
+  }
+  
+  public Iterable<SootMethod> getBfsTraversal() {
+    ArrayList<Node<SootMethod>> traversal = Algorithms.traverseBfs(shadowCallgraph);
+    Iterable<SootMethod> methods = fromShadowMethods(traversal);
+    return methods;
+  }
+  
+  public void printGraph() {
+    Collection<Node<SootMethod>> shadowMethodNodes = shadowCallgraph.getNodes();
+
+    for(Node<SootMethod> visitedNode : shadowMethodNodes) {
+      if(visitedNode == shadowCallgraph.startNode()
+          || visitedNode == shadowCallgraph.endNode())
+        continue;
+      
+      SootMethod m = visitedNode.getBody();
+      System.out.println(visitedNode);
+      
+      if(!m.isConcrete())
+        continue;
+      
+      ArrayList<Node<SootMethod>> neighbors = visitedNode.pointsTo();
+      
+      for(Node<SootMethod> neighbor : neighbors) {
+        System.out.format("\t↪ %s%n", neighbor);
+      }
+    }
+  }
+
+
+  private void makeShadowGraph() {
+    Iterator<Edge> edges = callgraph.iterator();
+
+    for(Edge edge : Items.items(edges)) {
+      SootMethod srcMethod = edge.src();
+      SootMethod tgtMethod = edge.tgt();
+
+      DebugUtil.printfln("Original Call Edge: %s => %s", srcMethod, tgtMethod);
+
+      Node<SootMethod> srcNode = getValidatedShadowNode(srcMethod);
+      if(srcNode == null)
+        continue;
+      
+      Node<SootMethod> tgtNode = getValidatedShadowNode(tgtMethod);
+      if(tgtNode == null)
+        continue;
+
+      srcNode.pointsTo(tgtNode);
+      DebugUtil.printfln("Shadow Call Edge: %s => %s", srcNode, tgtNode);
+    }
+  }
+  
+  private Node<SootMethod> getValidatedShadowNode(SootMethod srcMethod) {
+    if(srcMethod == null || !srcMethod.isConcrete()) {
+      return null;
+    }
+
+    Node<SootMethod> srcNode = getShadowMethod(srcMethod);
+    if(srcNode == null) {
+      return null;
+    }
+
+    MyAssert.assertThat(
+        srcMethod.equivHashCode() == srcNode.getBody().equivHashCode(),
+        String.format(
+            "Method Mismatch: Actual: %s, Shadow: %s", 
+            srcMethod, srcNode.getBody()));
+    
+    return srcNode;
+  }
+
+  private Node<SootMethod> getShadowMethod(SootMethod method) {
+    String label = method.getSignature();
+
+    Node<SootMethod> node = null;
+    if(shadowCallgraph.contains(label)) {
+      node = shadowCallgraph.node(label);
+    } else {
+      node = Node.create(label, method, this.shadowCallgraph);
+      this.shadowCallgraph.nowHas(node);
+    }
+
+    return node;
+  }
+  
+  private Iterable<SootMethod> fromShadowMethods(Iterable<Node<SootMethod>> shadowMethods) {
+    ArrayList<SootMethod> methods = new ArrayList<>();
+    for(Node<SootMethod> shadowMethod : shadowMethods) {
+      SootMethod method = shadowMethod.getBody();
+      if(method == null) {
+        continue;
+      }
+
+      methods.add(method);
+    }
+
+    return methods;
+  }
+  
+}

--- a/blinky-statik/src/main/java/org/spideruci/analysis/statik/calls/StatikCallGraphBuilder.java
+++ b/blinky-statik/src/main/java/org/spideruci/analysis/statik/calls/StatikCallGraphBuilder.java
@@ -1,4 +1,4 @@
-package org.spideruci.analysis.statik;
+package org.spideruci.analysis.statik.calls;
 
 import static org.spideruci.analysis.statik.SootCommander.RUN_SOOT;
 
@@ -8,6 +8,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+
+import org.spideruci.analysis.statik.DebugUtil;
+import org.spideruci.analysis.statik.SootCommander;
 
 import soot.PackManager;
 import soot.Scene;
@@ -29,8 +32,17 @@ public final class StatikCallGraphBuilder extends SceneTransformer {
    */
   private TreeMap<String, HashSet<String>> entrypoints = new TreeMap<>(); 
   
-  public static StatikCallGraphBuilder create(String graphId) {
-    return new StatikCallGraphBuilder(graphId);
+  public static StatikCallGraphBuilder build(String graphId, String[] args) {
+    StatikCallGraphBuilder scgBuilder = new StatikCallGraphBuilder(graphId);
+    
+    { // hook up SCG Builder with Soot
+      Transform cgBuilderTrans = new Transform("wjtp.cgbuilder", scgBuilder);
+      PackManager.v().getPack("wjtp").add(cgBuilderTrans);
+    }
+    
+    SootCommander.RUN_SOOT(args);
+    
+    return scgBuilder;
   }
   
   private StatikCallGraphBuilder(String graphId) {
@@ -39,6 +51,25 @@ public final class StatikCallGraphBuilder extends SceneTransformer {
   
   public String graphId() {
     return graphId;
+  }
+
+  public void addEntryPoint(String classname, String methodname) {
+    HashSet<String> methods = entrypoints.get(classname);
+    if(methods == null) {
+      methods = new HashSet<>();
+      entrypoints.put(classname, methods);
+    }
+    
+    methods.add(methodname);
+  }
+  
+  public CallGraph buildCallGraph() {
+    
+    return SootCommander.GET_CALLGRAPH();
+  }
+
+  public CallGraph getCallGraph() {
+    return SootCommander.GET_CALLGRAPH();
   }
   
   @SuppressWarnings("unused")
@@ -55,29 +86,6 @@ public final class StatikCallGraphBuilder extends SceneTransformer {
     COMPUTE_CALL_GRAPH: {
       CHATransformer.v().transform();
     }
-  }
-  
-  public void hookupWithSoot() {
-    Transform cgBuilderTrans = new Transform("wjtp.cgbuilder", this);
-    PackManager.v().getPack("wjtp").add(cgBuilderTrans);
-  }
-  
-  public void addEntryPoint(String classname, String methodname) {
-    HashSet<String> methods = entrypoints.get(classname);
-    if(methods == null) {
-      methods = new HashSet<>();
-      entrypoints.put(classname, methods);
-    }
-    
-    methods.add(methodname);
-  }
-  
-  public void buildCallGraph() {
-    
-  }
-
-  public CallGraph getCallGraph() {
-    return SootCommander.GET_CALLGRAPH();
   }
   
   // private method

--- a/blinky-statik/src/main/java/org/spideruci/analysis/statik/calls/StatikCallGraphBuilder.java
+++ b/blinky-statik/src/main/java/org/spideruci/analysis/statik/calls/StatikCallGraphBuilder.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.spideruci.analysis.statik.AnalysisConfig;
 import org.spideruci.analysis.statik.DebugUtil;
 import org.spideruci.analysis.statik.SootCommander;
 
@@ -32,14 +33,19 @@ public final class StatikCallGraphBuilder extends SceneTransformer {
    */
   private TreeMap<String, HashSet<String>> entrypoints = new TreeMap<>(); 
   
-  public static StatikCallGraphBuilder build(String graphId, String[] args) {
+  public static StatikCallGraphBuilder build(String graphId, AnalysisConfig config) {
     StatikCallGraphBuilder scgBuilder = new StatikCallGraphBuilder(graphId);
+    
+    scgBuilder.addEntryPoint(
+        config.get(AnalysisConfig.ENTRY_CLASS), 
+        config.get(AnalysisConfig.ENTRY_METHOD));
     
     { // hook up SCG Builder with Soot
       Transform cgBuilderTrans = new Transform("wjtp.cgbuilder", scgBuilder);
       PackManager.v().getPack("wjtp").add(cgBuilderTrans);
     }
     
+    String[] args = config.getArgs();
     SootCommander.RUN_SOOT(args);
     
     return scgBuilder;

--- a/blinky-statik/src/main/java/org/spideruci/analysis/statik/flow/IcfgManager.java
+++ b/blinky-statik/src/main/java/org/spideruci/analysis/statik/flow/IcfgManager.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.spideruci.analysis.statik.Items;
+import org.spideruci.analysis.statik.SootCommander;
 import org.spideruci.analysis.statik.Statik;
 import org.spideruci.analysis.statik.UnitIdTag;
 import org.spideruci.analysis.statik.controlflow.Graph;
@@ -133,7 +134,7 @@ public class IcfgManager {
 
   public void addSootMethodToIcfg(SootMethod method) {
     
-    UnitGraph graph = Statik.GET_UNIT_GRAPH(method);
+    UnitGraph graph = SootCommander.GET_UNIT_GRAPH(method);
     Items<Unit> units = new Items<Unit>(graph.iterator());
     for(Unit unit : units) {
       List<Unit> succs = graph.getSuccsOf(unit);

--- a/blinky-statik/src/main/resources/analysis.config
+++ b/blinky-statik/src/main/resources/analysis.config
@@ -2,3 +2,4 @@ jre7lib=/Users/vpalepu/open-source/java/golden/jre1.7.0_60.jre/Contents/Home/lib
 argclass=org.spideruci.analysis.statik.subjects.A
 entryclass=org.spideruci.analysis.statik.subjects.A
 entrymethod=foo
+debug=false


### PR DESCRIPTION
(Ref. Issue #29)

What:
This change introduces a clear API to manage the static call
graphs that is created with the help of Soot. This is supported
with a new CallGraphManager class that supports the following
methods in its API:
- getCallgraph
- getEntryPoints
- addEntryPoint
- methodExists
- getMethodCallers
- getMethodCallFrom
- getStrongComponents
- getBottomupTopology
- getDfsTraversal
- getBfsTraversal
- printGraph
  The new CallGraphManager is housed in a new package called
  analysis/statik/calls. This new package also houses the
  StatikCallGraphBuilder (earlier in analysis/statik) that
  talks to Soot directly to create the call graph.

Why:
This provides a clear API surface to deal with creation and
management of static call graphs, which are turning out to be
a quintessential data-structure for any form of static analysis.

Testing: mostly manual testing based on the CallGraphSubject in
the test source folder. This commit, did not change the call
graph and ICFG that was produced for the CallGraphSubject.
