### PR TITLE
Blinky Statik: Analysis Config: Call Graph Algorithm option

### DIFF
--- a/blinky-statik/src/main/java/org/spideruci/analysis/statik/AnalysisConfig.java
+++ b/blinky-statik/src/main/java/org/spideruci/analysis/statik/AnalysisConfig.java
@@ -10,12 +10,12 @@ import java.util.TreeMap;
 
 public class AnalysisConfig {
   
-  
   public final static String JRE7_LIB = "jre7lib";
   public final static String ARG_CLASS = "argclass";
   public final static String ENTRY_CLASS = "entryclass";
   public final static String ENTRY_METHOD = "entrymethod";
   public final static String DEBUG = "debug";
+  public final static String CALL_GRAPH_ALGO = "callgraph-algo";
   
   // Add new configuration file keys above here.
   

--- a/blinky-statik/src/main/java/org/spideruci/analysis/statik/calls/CallGraphAlgorithm.java
+++ b/blinky-statik/src/main/java/org/spideruci/analysis/statik/calls/CallGraphAlgorithm.java
@@ -1,0 +1,19 @@
+package org.spideruci.analysis.statik.calls;
+
+public enum CallGraphAlgorithm {
+  
+  CHA,
+  SPARK;
+    
+  public static CallGraphAlgorithm fromString(String name) {
+    switch(name) {
+    case "cha":
+      return CHA;
+    case "spark":
+      return SPARK;
+    default:
+      throw new RuntimeException();
+    }
+  }
+
+}

--- a/blinky-statik/src/main/resources/analysis.config
+++ b/blinky-statik/src/main/resources/analysis.config
@@ -1,5 +1,7 @@
 jre7lib=/Users/vpalepu/open-source/java/golden/jre1.7.0_60.jre/Contents/Home/lib
-argclass=org.spideruci.analysis.statik.subjects.A
-entryclass=org.spideruci.analysis.statik.subjects.A
-entrymethod=foo
+argclass=org.spideruci.analysis.statik.subjects.CallGraphSubject
+entryclass=org.spideruci.analysis.statik.subjects.CallGraphSubject
+entrymethod=doStuff
 debug=false
+# callgraph-algo options: cha, spark
+callgraph-algo=spark


### PR DESCRIPTION
What: This provides a new config option to specify the algorithm
to compute the call-graph. Specifically, we now have 2 algorithms
that can be used - CHA (call heirarchy analysis) and SPARK (which
is a form of CFA-based analysis that accounts for calling context
-- i think).

Why: This allows the Statik sub-module's users to generate different
call-graphs with trade-offs between speed and accuracy (CHA is faster,
SPARK is more accurate).

Testing: Tried out the call-graph option with `cha` and `spark` as
values for that option and manually inspected the resulting call-
graph.