### PR TITLE
Blinky: Maven Profiles: Selectively run Statik and Diagnostics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
   </profile>
 
   <profile>
-   <id>diagnose</id>
+   <id>diagnostics</id>
    <modules>
     <module>blinky-core</module>
     <module>blinky-util</module>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
  <modelVersion>4.0.0</modelVersion>
  <groupId>org.spideruci.analysis</groupId>
  <artifactId>blinky</artifactId>
@@ -41,8 +42,43 @@
   <module>blinky-core</module>
   <module>blinky-util</module>
   <module>blinky-trace-manager</module>
-  <module>blinky-diagnostics</module>
   <module>blinky-tacoco</module>
+ </modules>
+
+ <profiles>
+  <profile>
+   <id>statik</id>
+   <modules>
+    <module>blinky-core</module>
+    <module>blinky-util</module>
+    <module>blinky-trace-manager</module>
+    <module>blinky-tacoco</module>
     <module>blinky-statik</module>
-  </modules>
+   </modules>
+  </profile>
+
+  <profile>
+   <id>diagnose</id>
+   <modules>
+    <module>blinky-core</module>
+    <module>blinky-util</module>
+    <module>blinky-trace-manager</module>
+    <module>blinky-diagnostics</module>
+    <module>blinky-tacoco</module>
+   </modules>
+  </profile>
+
+  <profile>
+   <id>full</id>
+   <modules>
+    <module>blinky-core</module>
+    <module>blinky-util</module>
+    <module>blinky-trace-manager</module>
+    <module>blinky-diagnostics</module>
+    <module>blinky-tacoco</module>
+    <module>blinky-statik</module>
+   </modules>
+  </profile>
+ </profiles>
+
 </project>


### PR DESCRIPTION
Ref. Issue #36

Summary:
- Keeping the following modules as the default: core, util, trace-manager, tacoco; let's call it the default set
* This default set can be run using the regular command: `mvn compile test package install`

- Introducing **three** additional profiles in blinky's POM.xml (i.e. the parent project pom) for the following:
* statik -- this adds statik to the default set.
* diagnostics -- this adds diagnostics to the default set.
* full -- this adds statik and diagnostics to the default set.

- Following are the changes to the maven commands to invoke any of the three profiles:
* statik: `mvn -P statik compile test package install`
* diagnostics: `mvn -P diagnostics compile test package install`
* full: `mvn -P full compile test package install`