### PR TITLE
Statik pipelines

### DIFF
--- a/blinky-statik/pom.xml
+++ b/blinky-statik/pom.xml
@@ -46,4 +46,23 @@
     	<version>3.15.1</version>
     </dependency>
   </dependencies>
+  
+  <build>
+  
+  <plugins>
+          <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.2</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    
+  </plugins>
+  </build>
 </project>

--- a/blinky-statik/src/main/java/org/spideruci/analysis/statik/AnalysisConfig.java
+++ b/blinky-statik/src/main/java/org/spideruci/analysis/statik/AnalysisConfig.java
@@ -46,6 +46,10 @@ public class AnalysisConfig {
     return this.argsList.toArray(new String[0]);
   }
   
+  public boolean contains(final String key) {
+    return configs.containsKey(key);
+  }
+  
   public String get(final String key) {
     return configs.get(key);
   }

--- a/blinky-statik/src/main/java/org/spideruci/analysis/statik/Statik.java
+++ b/blinky-statik/src/main/java/org/spideruci/analysis/statik/Statik.java
@@ -7,6 +7,8 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
+import org.spideruci.analysis.statik.blocks.CallGraphBlock;
+import org.spideruci.analysis.statik.blocks.FlowBlock;
 import org.spideruci.analysis.statik.calls.CallGraphManager;
 import org.spideruci.analysis.statik.calls.StatikCallGraphBuilder;
 import org.spideruci.analysis.statik.controlflow.Graph;
@@ -76,42 +78,15 @@ public class Statik {
             
     StatikCallGraphBuilder cgBuilder = 
         StatikCallGraphBuilder.build("call-graph", analysisconfig);
-    
-    cgBuilder.addEntryPoint(
-        analysisconfig.get(AnalysisConfig.ENTRY_CLASS), 
-        analysisconfig.get(AnalysisConfig.ENTRY_METHOD));
 
-    SootMethod main = GET_MAIN_METHOD();
-//    SootMethod main = Scene.v().getMainClass().getMethodByName("testConstants");
-//    System.out.println(Scene.v().get);
-    
     CallGraph cg = cgBuilder.getCallGraph();
     
     CallGraphManager cgm = CallGraphManager.init(cg, GET_ENTRY_METHODS());
 
-    System.out.println("---- Call Graph ----");
+    new CallGraphBlock().run(cgm);
     
-    cgm.printGraph();
     
-    StatikFlowGraph flowGraph = StatikFlowGraph.init(cgm);
-        
-    System.out.println("---- I C F G ----");
-    
-    flowGraph.buildIcfg();
-    Graph<Unit> icfg = flowGraph.getIcfg();
-    System.out.println(icfg);
-        
-    System.out.println("---- Java Source Icfg ----");
-    
-    Graph<String> icfgGraph = flowGraph.icfgMgr.icfgJavaSourceLines();
-    System.out.println(icfgGraph);    
-    
-    System.out.println("---- Writing to Database ----");
-  
-    SourceICFG sIcfg = new SourceICFG(icfgGraph);
-    sIcfg.dumpData();
-    
-    System.out.println("Done!");
+    new FlowBlock().run(cgm);
     
   }
 

--- a/blinky-statik/src/main/java/org/spideruci/analysis/statik/Statik.java
+++ b/blinky-statik/src/main/java/org/spideruci/analysis/statik/Statik.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
+import org.spideruci.analysis.statik.blocks.AnalysisBlock;
 import org.spideruci.analysis.statik.blocks.CallGraphBlock;
 import org.spideruci.analysis.statik.blocks.FlowBlock;
 import org.spideruci.analysis.statik.calls.CallGraphManager;
@@ -83,10 +84,20 @@ public class Statik {
     
     CallGraphManager cgm = CallGraphManager.init(cg, GET_ENTRY_METHODS());
 
-    new CallGraphBlock().run(cgm);
+    List<Class<? extends AnalysisBlock>> analysisBlocks = analysisconfig.getBlocks();
+    for(Class<? extends AnalysisBlock> block : analysisBlocks) {
+      try {
+        AnalysisBlock liveBlock = block.newInstance();
+        liveBlock.execute(cgm);
+      } catch (InstantiationException | IllegalAccessException e) {
+        e.printStackTrace();
+      }
+    }
+    
+//    new CallGraphBlock().run(cgm);
     
     
-    new FlowBlock().run(cgm);
+//    new FlowBlock().run(cgm);
     
   }
 

--- a/blinky-statik/src/main/java/org/spideruci/analysis/statik/blocks/AnalysisBlock.java
+++ b/blinky-statik/src/main/java/org/spideruci/analysis/statik/blocks/AnalysisBlock.java
@@ -1,0 +1,9 @@
+package org.spideruci.analysis.statik.blocks;
+
+import org.spideruci.analysis.statik.calls.CallGraphManager;
+
+public abstract class AnalysisBlock {
+  
+  public abstract void run(CallGraphManager cgm);
+
+}

--- a/blinky-statik/src/main/java/org/spideruci/analysis/statik/blocks/AnalysisBlock.java
+++ b/blinky-statik/src/main/java/org/spideruci/analysis/statik/blocks/AnalysisBlock.java
@@ -4,6 +4,6 @@ import org.spideruci.analysis.statik.calls.CallGraphManager;
 
 public abstract class AnalysisBlock {
   
-  public abstract void run(CallGraphManager cgm);
+  public abstract void execute(CallGraphManager cgm);
 
 }

--- a/blinky-statik/src/main/java/org/spideruci/analysis/statik/blocks/CallGraphBlock.java
+++ b/blinky-statik/src/main/java/org/spideruci/analysis/statik/blocks/CallGraphBlock.java
@@ -1,0 +1,35 @@
+package org.spideruci.analysis.statik.blocks;
+
+import org.spideruci.analysis.statik.calls.CallGraphManager;
+
+import soot.SootMethod;
+
+public class CallGraphBlock extends AnalysisBlock {
+
+  @Override
+  public void run(CallGraphManager cgm) {
+
+    System.out.println("----");
+
+    int i = 0;
+    for(SootMethod method : cgm.getBfsTraversal()) {
+      System.out.println(method);
+      i += 1;
+    }
+    System.out.println(i);
+
+    System.out.println("----");
+    int j = 0;
+    for(SootMethod method : cgm.getBottomupTopology()) {
+      j += 1;
+      System.out.println(method);
+    }
+    System.out.println(j);
+
+    System.out.println("---- Call Graph ----");
+
+    cgm.printGraph();
+
+  }
+
+}

--- a/blinky-statik/src/main/java/org/spideruci/analysis/statik/blocks/CallGraphBlock.java
+++ b/blinky-statik/src/main/java/org/spideruci/analysis/statik/blocks/CallGraphBlock.java
@@ -7,7 +7,7 @@ import soot.SootMethod;
 public class CallGraphBlock extends AnalysisBlock {
 
   @Override
-  public void run(CallGraphManager cgm) {
+  public void execute(CallGraphManager cgm) {
 
     System.out.println("----");
 

--- a/blinky-statik/src/main/java/org/spideruci/analysis/statik/blocks/FlowBlock.java
+++ b/blinky-statik/src/main/java/org/spideruci/analysis/statik/blocks/FlowBlock.java
@@ -10,7 +10,7 @@ import soot.Unit;
 public class FlowBlock extends AnalysisBlock {
 
   @Override
-  public void run(CallGraphManager cgm) {
+  public void execute(CallGraphManager cgm) {
     StatikFlowGraph flowGraph = StatikFlowGraph.init(cgm);
     
     System.out.println("---- I C F G ----");

--- a/blinky-statik/src/main/java/org/spideruci/analysis/statik/blocks/FlowBlock.java
+++ b/blinky-statik/src/main/java/org/spideruci/analysis/statik/blocks/FlowBlock.java
@@ -1,0 +1,36 @@
+package org.spideruci.analysis.statik.blocks;
+
+import org.spideruci.analysis.statik.calls.CallGraphManager;
+import org.spideruci.analysis.statik.controlflow.Graph;
+import org.spideruci.analysis.statik.flow.StatikFlowGraph;
+import org.spideruci.analysis.statik.flow.data.SourceICFG;
+
+import soot.Unit;
+
+public class FlowBlock extends AnalysisBlock {
+
+  @Override
+  public void run(CallGraphManager cgm) {
+    StatikFlowGraph flowGraph = StatikFlowGraph.init(cgm);
+    
+    System.out.println("---- I C F G ----");
+    
+    flowGraph.buildIcfg();
+    Graph<Unit> icfg = flowGraph.getIcfg();
+    System.out.println(icfg);
+        
+    System.out.println("---- Java Source Icfg ----");
+    
+    Graph<String> icfgGraph = flowGraph.icfgMgr.icfgJavaSourceLines();
+    System.out.println(icfgGraph);    
+    
+//    System.out.println("---- Writing to Database ----");
+//  
+    SourceICFG sIcfg = new SourceICFG(icfgGraph);
+    sIcfg.dumpData();
+    
+    System.out.println("Done!");
+    
+  }
+
+}

--- a/blinky-statik/src/main/java/org/spideruci/analysis/statik/calls/CallGraphManager.java
+++ b/blinky-statik/src/main/java/org/spideruci/analysis/statik/calls/CallGraphManager.java
@@ -4,8 +4,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map.Entry;
 
 import org.spideruci.analysis.statik.DebugUtil;
 import org.spideruci.analysis.statik.Items;
@@ -115,7 +117,11 @@ public class CallGraphManager {
   }
   
   public Iterable<SootMethod> getBottomupTopology() {
-    Algorithms.collapseStrongComponents(shadowCallgraph);
+    
+    HashMap<Node<SootMethod>, Node<SootMethod>> leaders = 
+        Algorithms.collapseStrongComponents(shadowCallgraph);
+    
+    System.out.println(new HashSet<>(leaders.values()).size());
     
     ArrayList<Node<SootMethod>> topology = 
         Algorithms.bottomUpTopologicalSort(shadowCallgraph);
@@ -133,7 +139,9 @@ public class CallGraphManager {
   }
   
   public Iterable<SootMethod> getBfsTraversal() {
-    ArrayList<Node<SootMethod>> traversal = Algorithms.traverseBfs(shadowCallgraph);
+    Collection<Node<SootMethod>> traversal = shadowCallgraph.getNodes();// Algorithms.traverseBfs(shadowCallgraph);
+    System.out.println(shadowCallgraph.getNodes().size());
+//    System.out.println(traversal.size());
     Iterable<SootMethod> methods = fromShadowMethods(traversal);
     return methods;
   }
@@ -147,7 +155,7 @@ public class CallGraphManager {
         continue;
       
       SootMethod m = visitedNode.getBody();
-      System.out.println(visitedNode);
+      System.out.println(visitedNode.getLabel());
       
       if(!m.isConcrete())
         continue;
@@ -155,7 +163,7 @@ public class CallGraphManager {
       ArrayList<Node<SootMethod>> neighbors = visitedNode.pointsTo();
       
       for(Node<SootMethod> neighbor : neighbors) {
-        System.out.format("\t↪ %s%n", neighbor);
+        System.out.format("\t↪ %s%n", neighbor.getLabel());
       }
     }
   }

--- a/blinky-statik/src/main/java/org/spideruci/analysis/statik/calls/StatikCallGraphBuilder.java
+++ b/blinky-statik/src/main/java/org/spideruci/analysis/statik/calls/StatikCallGraphBuilder.java
@@ -1,5 +1,8 @@
 package org.spideruci.analysis.statik.calls;
 
+import static org.spideruci.analysis.statik.AnalysisConfig.ENTRY_CLASS;
+import static org.spideruci.analysis.statik.AnalysisConfig.ENTRY_METHOD;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -41,9 +44,10 @@ public final class StatikCallGraphBuilder extends SceneTransformer {
     StatikCallGraphBuilder scgBuilder = 
         new StatikCallGraphBuilder(graphId, cgAlgo);
     
-    scgBuilder.addEntryPoint(
-        config.get(AnalysisConfig.ENTRY_CLASS), 
-        config.get(AnalysisConfig.ENTRY_METHOD));
+    if(config.contains(ENTRY_CLASS) && config.contains(ENTRY_METHOD)) {
+      scgBuilder.addEntryPoint(config.get(ENTRY_CLASS), config.get(ENTRY_METHOD));
+    }
+
     
     { // hook up SCG Builder with Soot
       Transform cgBuilderTrans = new Transform("wjtp.cgbuilder", scgBuilder);
@@ -133,7 +137,9 @@ public final class StatikCallGraphBuilder extends SceneTransformer {
       }
     }
     
-    Scene.v().setEntryPoints(entryPoints);
+    if(!entryPoints.isEmpty()) {
+      Scene.v().setEntryPoints(entryPoints);
+    }
   }
   
   /**

--- a/blinky-statik/src/main/java/org/spideruci/analysis/statik/flow/StatikFlowGraph.java
+++ b/blinky-statik/src/main/java/org/spideruci/analysis/statik/flow/StatikFlowGraph.java
@@ -111,7 +111,14 @@ public class StatikFlowGraph {
     }
   
     private boolean methodIsInvalid(SootMethod method) {
-      return method == null || !method.isConcrete();
+      return method == null 
+          || !method.isConcrete() 
+          || methodBodyIsInvalid(method.retrieveActiveBody());
+    }
+    
+    private boolean methodBodyIsInvalid(Body body) {
+      PatchingChain<Unit> units = body == null ? null : body.getUnits();
+      return units == null || units.isEmpty();
     }
   
     private ArrayList<SootMethod> initWorklist() {

--- a/blinky-statik/src/main/resources/analysis.config
+++ b/blinky-statik/src/main/resources/analysis.config
@@ -1,8 +1,8 @@
 jre7lib=/Users/vpalepu/open-source/java/golden/jre1.7.0_60.jre/Contents/Home/lib
 
 argclass=org.spideruci.analysis.statik.subjects.CallGraphSubject
-#entryclass=org.spideruci.analysis.statik.subjects.CallGraphSubject
-#entrymethod=doStuff
+entryclass=org.spideruci.analysis.statik.subjects.CallGraphSubject
+entrymethod=doStuff
 
 debug=false
 
@@ -14,3 +14,5 @@ callgraph-algo=cha
 classpath=./target/test-classes/
 #sutjarpath=/Users/Ku/workspace/joda-time/target/joda-time-2.9.5-SNAPSHOT-jar-with-dependencies.jar
 #classpath=/Users/Ku/workspace/joda-time/target/test-classes
+// $org.spideruci.analysis.statik.blocks.CallGraphBlock
+$   org.spideruci.analysis.statik.blocks.FlowBlock

--- a/blinky-statik/src/main/resources/analysis.config
+++ b/blinky-statik/src/main/resources/analysis.config
@@ -1,13 +1,13 @@
 jre7lib=/Users/vpalepu/open-source/java/golden/jre1.7.0_60.jre/Contents/Home/lib
 
 argclass=org.spideruci.analysis.statik.subjects.CallGraphSubject
-entryclass=org.spideruci.analysis.statik.subjects.CallGraphSubject
-entrymethod=doStuff
+#entryclass=org.spideruci.analysis.statik.subjects.CallGraphSubject
+#entrymethod=doStuff
 
 debug=false
 
 # callgraph-algo options: cha, spark
-callgraph-algo=spark
+callgraph-algo=cha
 
 # Use sutjarpath and classpath to setup directories and jar files 
 # to the classpath for Soot to perform the analysis appropriately.

--- a/blinky-statik/src/test/java/org/spideruci/analysis/statik/subjects/CallGraphSubject.java
+++ b/blinky-statik/src/test/java/org/spideruci/analysis/statik/subjects/CallGraphSubject.java
@@ -19,15 +19,15 @@ class A {
   B field;
   
   public void foo() {
-    bar();
+//    bar(new B());
   }
   
-  private int bar() {
-    this.field = new B();
+  public int bar(B arg) {
+    this.field = arg;
     B temp = this.field;
     int localFoo = temp.foo;
     
-    temp.foo();
+//    temp.foo();
     
     temp.foo = temp.foo + this.field.foo;
     


### PR DESCRIPTION
(Ref. Issue #39)

What: With this change - this commit and the commit before this (1ab146c),
we are now able to weave multiple executable blocks that
implement some form of static analysis, in a single pipeline.

Why: This basically sets up different analyses that devs may want
to implement and execute on the same code/system under analysis.
Essentially, no more changing the main method in Statik class to
change the kind of static analysis to be run on the code under
analysis ... All changes to the config file.

Details:

- AnalysisBlock Class
Specifically, all analysis code will be implemented in classes that
extend the `AnalysisBlock` class in the `org.spideruci.analysis.statik.blocks`
package. This class has an `execute` method that is required by
the sub-classes to implement. This method takes as input an instance
of the `ClassGraphManager`. This gives all analysis-block access
to the call graph of code/system under analysis. All these classes
are implemented under the package `org.spideruci.analysis.statik.blocks`.

- Specifying AnalysisBlocks in Config File
The AnalysisBlocks are executed when they are specified in the con-
fig file. If the blocks are to be considered for execution, they
should be prepended with the dollar sign (`$`). Further, they must
be specified with the fully qualified names of the sub-class (i.e.,
with the package name) that is implementing the `AnalysisBlock`
class.

- The Executor Look in Statik.java
An exec loop in Statik will create an instance for each sub-class
specified in the Config file. The execute method on each of those
instances will then be executed, while passing along the Call Graph
manager of the code under analysis to each `execute` invocations.