### PR TITLE
Buildfix for mvn compile -P static

### DIFF
--- a/blinky-config/pom.xml
+++ b/blinky-config/pom.xml
@@ -63,6 +63,35 @@
       </plugin>
     
     </plugins>
+    <pluginManagement>
+     <plugins>
+      <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+      <plugin>
+       <groupId>org.eclipse.m2e</groupId>
+       <artifactId>lifecycle-mapping</artifactId>
+       <version>1.0.0</version>
+       <configuration>
+        <lifecycleMappingMetadata>
+         <pluginExecutions>
+          <pluginExecution>
+           <pluginExecutionFilter>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <versionRange>[2.2-beta-5,)</versionRange>
+            <goals>
+             <goal>single</goal>
+            </goals>
+           </pluginExecutionFilter>
+           <action>
+            <execute></execute>
+           </action>
+          </pluginExecution>
+         </pluginExecutions>
+        </lifecycleMappingMetadata>
+       </configuration>
+      </plugin>
+     </plugins>
+    </pluginManagement>
   </build>
 
 </project>

--- a/blinky-core/pom.xml
+++ b/blinky-core/pom.xml
@@ -123,6 +123,48 @@
    </plugin>
    
   </plugins>
+  <pluginManagement>
+   <plugins>
+    <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+    <plugin>
+     <groupId>org.eclipse.m2e</groupId>
+     <artifactId>lifecycle-mapping</artifactId>
+     <version>1.0.0</version>
+     <configuration>
+      <lifecycleMappingMetadata>
+       <pluginExecutions>
+        <pluginExecution>
+         <pluginExecutionFilter>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-clean-plugin</artifactId>
+          <versionRange>[3.0.0,)</versionRange>
+          <goals>
+           <goal>clean</goal>
+          </goals>
+         </pluginExecutionFilter>
+         <action>
+          <ignore></ignore>
+         </action>
+        </pluginExecution>
+        <pluginExecution>
+         <pluginExecutionFilter>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <versionRange>[1.5.0,)</versionRange>
+          <goals>
+           <goal>java</goal>
+          </goals>
+         </pluginExecutionFilter>
+         <action>
+          <execute></execute>
+         </action>
+        </pluginExecution>
+       </pluginExecutions>
+      </lifecycleMappingMetadata>
+     </configuration>
+    </plugin>
+   </plugins>
+  </pluginManagement>
  </build>
 
  <dependencies>

--- a/blinky-statik/pom.xml
+++ b/blinky-statik/pom.xml
@@ -19,9 +19,9 @@
   </properties>
   <dependencies>
     <dependency>
-     <groupId>org.spideruci.analysis.statik.controlflow</groupId>
-     <artifactId>jump</artifactId>
-     <version>1.0-SNAPSHOT</version>
+      <groupId>org.spideruci.analysis.util</groupId>
+      <artifactId>blinky-util</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
     </dependency>
      
     <dependency>

--- a/blinky-util/pom.xml
+++ b/blinky-util/pom.xml
@@ -25,8 +25,8 @@
     <artifactId>maven-compiler-plugin</artifactId>
     <version>3.1</version>
     <configuration>
-     <source>1.7</source>
-     <target>1.7</target>
+     <source>1.8</source>
+     <target>1.8</target>
     </configuration>
    </plugin>
   </plugins>

--- a/blinky-util/src/main/java/org/spideruci/analysis/statik/controlflow/Accumulator.java
+++ b/blinky-util/src/main/java/org/spideruci/analysis/statik/controlflow/Accumulator.java
@@ -1,0 +1,66 @@
+package org.spideruci.analysis.statik.controlflow;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.function.Consumer;
+
+/**
+ * A collection that is designed to only add Node elements to a list
+ * return such a list upon adding all desired Nodes.
+ * @author vpalepu
+ *
+ * @param <T>
+ */
+public class Accumulator<T> {
+  
+  private ArrayList<Node<T>> accumulated;
+  
+  /**
+   * Creates an Accumulator instance.
+   * @return
+   */
+  public static <A> Accumulator<A> create() {
+    return new Accumulator<A>();
+  }
+  
+  private Accumulator() {
+    accumulated = new ArrayList<>();
+  }
+  
+  /**
+   * Retrieves the current list of Nodes accumulated so far.
+   * @return
+   */
+  public ArrayList<Node<T>> period() {
+    return new ArrayList<Node<T>>(accumulated);
+  }
+  
+  public ArrayList<Node<T>> andAlso(Node<T> node) {
+    accumulated.add(node);
+    return new ArrayList<>(accumulated);
+  }
+  
+  public Accumulator<T> and(Node<T> node) {
+    this.accumulated.add(node);
+    return this;
+  }
+  
+  public Accumulator<T> with(Node<T>[] nodes) {
+    for(Node<T> node : nodes) {
+      and(node);
+    }
+    return this;
+  }
+  
+  public Accumulator<T> with(Collection<Node<T>> nodes) {
+    for(Node<T> node : nodes) {
+      and(node);
+    }
+    return this;
+  }
+  
+  public void forEach(Consumer<Node<T>> c) {
+    accumulated.forEach(c);
+  }
+  
+}

--- a/blinky-util/src/main/java/org/spideruci/analysis/statik/controlflow/Algorithms.java
+++ b/blinky-util/src/main/java/org/spideruci/analysis/statik/controlflow/Algorithms.java
@@ -1,0 +1,511 @@
+package org.spideruci.analysis.statik.controlflow;
+
+import static org.spideruci.analysis.util.caryatid.Helper.Collections2.emptyArrayList;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.Random;
+import java.util.Stack;
+import com.google.common.base.Preconditions;
+
+public class Algorithms {
+  
+  public static <T> ArrayList<Node<T>> randomWalkBack(Node<T> initialNode) {
+    ArrayList<Node<T>> randomWalkBack = new ArrayList<Node<T>>();
+    Node<T> currentNode = initialNode;
+    randomWalkBack.add(currentNode);
+    while(!currentNode.isPointedByNone()) {
+      ArrayList<Node<T>> predecessors = currentNode.getPredecessors();
+      currentNode = predecessors.get(new Random().nextInt(predecessors.size()));
+      randomWalkBack.add(currentNode);
+    }
+    return randomWalkBack;
+  }
+  
+  public static <T> ArrayList<Node<T>> traverseReversePostOrder(Node<T> root) {
+    return reverseTraversalOrder(traversePostOrder(root));
+  }
+  
+  public static <T> ArrayList<Node<T>> traversePostOrder(Node<T> root) {
+    if(root == null || root.pointsTo() == null || root.pointsToNone()) {
+      return emptyArrayList();
+    }
+    
+    Stack<Node<T>> stack  = new Stack<>();
+    HashSet<Node<T>> visited = new HashSet<>();
+    ArrayList<Node<T>> traversal = new ArrayList<>();
+    stack.push(root);
+    visited.add(root);
+    
+    while(!stack.isEmpty()) {
+      Node<T> top = stack.peek();
+      
+      Node<T> unvisitedNeighbour = null;
+      for(Node<T> item : top.pointsTo()) {
+        if(!visited.contains(item)) {
+          unvisitedNeighbour = item;
+          break;
+        }
+      }
+      
+      if(unvisitedNeighbour != null) {
+        visited.add(unvisitedNeighbour);
+        stack.push(unvisitedNeighbour);
+      } else {
+        Node<T> popped = stack.pop();
+        traversal.add(popped);
+      }
+    }
+    
+    return traversal;
+  }
+  
+  public static <T> ArrayList<Node<T>> reverseTraversalOrder(ArrayList<Node<T>> trav) {
+    if(trav == null || trav.isEmpty()) 
+      return emptyArrayList();
+    
+    ArrayList<Node<T>> revTrav = new ArrayList<>(trav);
+    Collections.reverse(revTrav);
+    return revTrav;
+  }
+  
+  public static <T> ArrayList<Node<T>> traverseBfs(Graph<T> graph) {
+    ArrayList<Node<T>> bfsTraversal = new ArrayList<>();
+    
+    LinkedList<Node<T>> qu = new LinkedList<>();
+    qu.addLast(graph.startNode());
+    
+    while(!qu.isEmpty()) {
+      Node<T> front = qu.removeFirst();
+      
+      if(front == null)
+        continue;
+      
+      bfsTraversal.add(front);
+      
+      ArrayList<Node<T>> succs = front.pointsTo();
+      
+      for(Node<T> succ : succs) {
+        if(bfsTraversal.contains(succ))
+          continue;
+        
+        qu.addLast(succ);
+      }
+    }
+    
+    return bfsTraversal;
+  }
+  
+  public static <T> ArrayList<Node<T>> traverseDfs(Graph<T> graph) {
+    ArrayList<Node<T>> dfsTraversal = new ArrayList<>();
+    
+    Stack<Node<T>> stack = new Stack<>();
+    stack.push(graph.startNode());
+    
+    while(!stack.isEmpty()) {
+      Node<T> popped = stack.pop();
+      
+      if(popped == null)
+        continue;
+      
+      dfsTraversal.add(popped);
+      
+      ArrayList<Node<T>> succs = popped.pointsTo();
+      
+      for(Node<T> succ : succs) {
+        if(dfsTraversal.contains(succ))
+          continue;
+        
+        stack.push(succ);
+      }
+    }
+    
+    return dfsTraversal;
+  }
+  
+  public static <T> ArrayList<Node<T>> traverseReversePostOrder(Graph<T> graph) {
+    Graph<T> spanningTree = getDfsSpanningTree(graph);
+    return traverseBfs(spanningTree);
+  }
+  
+  public static <T> Graph<T> getDfsSpanningTree(Graph<T> flowGraph) {
+    validateGraph(flowGraph);
+    
+    Graph<T> tree = Graph.createEmptyGraph();
+    
+    Stack<Node<T>> stack = new Stack<>();
+    stack.push(flowGraph.startNode());
+    
+    while(!stack.isEmpty()) {
+      Node<T> popped = stack.pop();
+      if(popped == null)
+        continue;
+      
+      final String poppedLabel = popped.getLabel();
+      
+      Node<T> poppedInTree = null;
+      if(tree.contains(poppedLabel)) {
+        poppedInTree = tree.node(poppedLabel);
+      } else {
+        poppedInTree = Node.create(poppedLabel, tree);
+        tree.nowHas(poppedInTree);
+      }
+
+      ArrayList<Node<T>> succs = popped.pointsTo();
+      for(Node<T> succ : succs) {
+        final String succLabel = succ.getLabel();
+        
+        if(tree.contains(succLabel)) {
+          continue;
+        }
+        
+        Node<T> succInTree = Node.create(succLabel, tree);
+        tree.nowHas(succInTree);
+        poppedInTree.pointsTo(succInTree);
+//        succInTree.po
+        
+        stack.push(succ);
+      }
+      
+    }
+    
+    return tree;
+  }
+  
+  public static <T> HashMap<Node<T>, Node<T>> getStronglyConnectedComponents(Graph<T> flowGraph) {
+    validateGraph(flowGraph);
+    
+    Node<T> start = flowGraph.startNode();
+    ArrayList<Node<T>> postOrderTraversal = traversePostOrder(start);
+    
+    HashMap<Node<T>, Node<T>> ringleaders = new HashMap<>();
+    
+    for(int i = postOrderTraversal.size() - 1; i >= 0; i -= 1) {
+      Node<T> leader = postOrderTraversal.get(i);
+      if(ringleaders.get(leader) != null) {
+        continue;
+      }
+      
+      Stack<Node<T>> stack = new Stack<>();
+      stack.push(leader);
+      while(!stack.isEmpty()) {
+        Node<T> popped = stack.pop();
+        if(popped == null) {
+          continue;
+        }
+        
+        if(ringleaders.get(popped) == null) {
+          ringleaders.put(popped, leader);
+        }
+        
+        ArrayList<Node<T>> preds = popped.getPredecessors();
+        for(Node<T> pred : preds) {
+          if(ringleaders.get(pred) == null) {
+            stack.push(pred);
+          }
+        }
+        
+      }
+    }
+    
+    return ringleaders;
+  }
+  
+  /**
+   * 
+   * @param flowGraph
+   * @return dictionary of nodes, mapped to their leaders for all the 
+   * identified strongly connected components.
+   */
+  public static <T> HashMap<Node<T>, Node<T>> collapseStrongComponents(Graph<T> flowGraph) {
+    validateGraph(flowGraph);
+    
+    HashMap<Node<T>, Node<T>> ringleaders = 
+        getStronglyConnectedComponents(flowGraph);
+    
+    for(Node<T> node : ringleaders.keySet()) {
+      Node<T> leader = ringleaders.get(node);
+      if(node == leader) {
+        continue;
+      }
+
+      ArrayList<Node<T>> succs = node.pointsTo();
+      for(Node<T> succ : succs) {
+        if(succ == null) 
+          continue;
+        Node<T> succLeader = ringleaders.get(succ);
+
+        if(succLeader == leader)
+          continue;
+
+        if(!leader.containsSuccessor(succLeader.getLabel())) {
+          leader.pointsTo(succLeader);
+        }
+      }
+      
+      ArrayList<Node<T>> preds = node.getPredecessors();
+      for(Node<T> pred : preds) {
+        if(pred == null) 
+          continue;
+        
+        Node<T> predLeader = ringleaders.get(pred);
+        
+        if(predLeader == leader)
+          continue;
+        
+        if(!predLeader.containsSuccessor(leader.getLabel())) {
+          predLeader.pointsTo(leader);
+        }
+      }
+      
+      node.clearPredecessors();
+      node.clearSuccessors();
+    }
+    
+    return ringleaders;
+  }
+  
+
+  /**
+   * This method does not account for any strongly connected components 
+   * in the input flowGraph. To avoid any issues due to SCCs (strongly 
+   * connected components) use the method {@link Algorithms.collapseStrongComponents} 
+   * to collapse the SCCs before calling this method. 
+   * @param flowGraph
+   * @return
+   */
+  public static <T> ArrayList<Node<T>> bottomUpTopologicalSort(Graph<T> flowGraph) {
+    validateGraph(flowGraph);
+    
+    ArrayList<Node<T>> topologicalSort = new ArrayList<>();
+    LinkedList<Node<T>> qu = new LinkedList<>(); 
+    
+    for(Node<T> node : flowGraph.getNodes()) {
+      if(node.pointsToNone()) {
+        qu.addLast(node);
+      }
+    }
+    
+    while(!qu.isEmpty()) {
+      Node<T> front = qu.removeFirst();
+      
+      if(front == null)
+        continue;
+      
+      topologicalSort.add(front);
+      
+      ArrayList<Node<T>> preds = front.getPredecessors();
+      front.clearPredecessors();
+      for(Node<T> pred : preds) {
+        if(pred.pointsToNone()) {
+          qu.addLast(pred);
+        }
+      }
+      
+    }
+    
+    return topologicalSort;
+  }
+  
+  /**
+   * 
+   * @param flowGraph The control flow graph for which a dominator tree is constructed and returned.
+   * @return The Dominatory Tree <a href="https://en.wikipedia.org/wiki/Dominator_(graph_theory)">(ref)</a>
+   * for the input {@code flowgraph}.
+   * @throws @{@link IllegalArgumentException} when: <br>
+   * <li> {@code flowgraph} is null
+   * <li> {@code flowgraph} is empty (lacks start and end nodes);
+   * <li> START and/or END nodes are null
+   * <li> START points to nothing
+   * <li> END is pointed by nothing
+   * 
+   * @throws @{@link IllegalStateException} when Reverse post order traversal's 
+   * node-count does not match {@code flowgraph}'s node count, typically because
+   * the input {@code flowgraph} is actually a forest.
+   */
+  public static <T> Graph<T> getDominatorTree(Graph<T> flowGraph) {
+    validateGraph(flowGraph);
+    
+    Node<T> root = flowGraph.startNode();
+    ArrayList<Node<T>> revPostOrder = traverseReversePostOrder(root);
+    Preconditions.checkState(flowGraph.getNodes().size() == revPostOrder.size(),
+        flowGraph +  " " + revPostOrder);
+    
+    Graph<T> domTree = Graph.createEmptyGraph();
+    String rootLabel = root.getLabel();
+    Node<T> domTreeRoot = Node.create(rootLabel, domTree);
+    domTree.nowHas(domTreeRoot);
+    
+    for(int i = 1; i < revPostOrder.size(); i += 1) {
+      Node<T> flowNode = revPostOrder.get(i);
+      
+      ArrayList<Node<T>> flowPreds = flowNode.getPredecessors();
+      
+      Node<T> iDom = null;
+      
+      for(Node<T> flowPred : flowPreds) {
+        String flowPredLabel = flowPred.getLabel();
+        if(!domTree.contains(flowPredLabel))
+          continue;
+        
+        // get the predecessor's idom
+        Node<T> predInDomTree = domTree.node(flowPredLabel);
+        iDom = (iDom == null) ? predInDomTree : lowestCommonAncestor(iDom, predInDomTree);
+//        
+//        Node<T> predIdom;
+//        if(nodeInDomTree == domTreeRoot) {
+//          predIdom = domTreeRoot;
+//        } else {
+//          ArrayList<Node<T>> idoms = nodeInDomTree.getPredecessors();
+//          Preconditions.checkState(idoms.size() == 1, idoms.size());
+//          predIdom = idoms.get(0);
+//        }
+        
+        
+      }
+      
+      String label = flowNode.getLabel();
+      Node<T> newDomNode = Node.create(label, domTree);
+      domTree.nowHas(newDomNode);
+      iDom.pointsTo(newDomNode);
+    }
+    
+    return domTree;
+  }
+
+  private static <T> void validateGraph(Graph<T> flowGraph) {
+    Preconditions.checkArgument(flowGraph != null, "flowgraph is null");
+    Preconditions.checkArgument(!flowGraph.getNodes().isEmpty(), "flowgraph is empty");
+    Preconditions.checkArgument(flowGraph.startNode() != null, "flowgraph's start is null");
+    Preconditions.checkArgument(flowGraph.endNode() != null, "flowgraph's end is null");
+    Preconditions.checkArgument(flowGraph.startNode().getSuccessorsSize() != 0, 
+        "flowgraph's start points to nothing");
+    Preconditions.checkArgument(flowGraph.startNode().getSuccessorsSize() != 0,
+        "nothing points to flowgraph's end");
+  }
+  
+  /**
+   * Finds the lowest common ancestor for the input Nodes n1 and n2.
+   * Assumes that the nodes are a part of the same TREE, not GRAPH.
+   * I.E., each node only as a single predecessor.
+   * Given the TREE-assumption, while traversing parents of the nodes, it will
+   * pick a node's first predecessor.
+   * @param n1
+   * @param n2
+   * @return The lowest common ancestor for the input nodes
+   * @throws @{@link IllegalStateException} in case {@code n1} and/or {@code n2} <br> 
+   * <li> are null;
+   * <li> do not belong to the same tree; or 
+   * <li> if they do belong to a graph instead of a tree.  
+   */
+  public static <T> Node<T> lowestCommonAncestor(Node<T> n1, Node<T> n2) {
+    Preconditions.checkState(n1 != null && n2 != null);
+    Preconditions.checkState(n1.getContainerGraph() == n2.getContainerGraph());
+    
+    ArrayList<Node<T>> n1ToRoot = new ArrayList<>();
+    ArrayList<Node<T>> n2ToRoot = new ArrayList<>();
+    
+    for(Node<T> ptr = n1; ptr != null; ptr = ptr.getParentInTree()) {
+      if(ptr == n2)
+        return n2;
+      
+      n1ToRoot.add(ptr);
+    }
+    
+    for(Node<T> ptr = n2; ptr != null; ptr = ptr.getParentInTree()) {
+      if(ptr == n1)
+        return n1;
+      
+      n2ToRoot.add(ptr);
+    }
+    
+    Node<T> lca = null;
+    
+    for(int i = n1ToRoot.size() - 1, j = n2ToRoot.size() - 1;
+        j >= 0 && i >= 0 && n1ToRoot.get(i) == n2ToRoot.get(j); 
+        i -= 1, j -= 1) {
+      lca = n1ToRoot.get(i);
+    }
+    
+    return lca;
+  }
+  
+  @Deprecated
+  public static <T> Graph<T> computeDomTree(Node<T> root) {
+    
+    ArrayList<Node<T>> postOrder = traversePostOrder(root);
+    if(postOrder.isEmpty()) {
+      return null;
+    }
+    
+    ArrayList<Node<T>> revPostOrder = reverseTraversalOrder(postOrder);
+    
+    Graph<T> domTree = Graph.createEmptyGraph();
+    
+    for(Node<T> node : revPostOrder) {
+      domTree.nowHas(Node.<T>create(node.getLabel(), domTree));
+    }
+    
+    root.cloneIn(domTree).pointsTo(root.cloneIn(domTree));
+    
+    boolean domTreeChanged = true;
+    
+    
+    HashMap<String, Integer> postOrderPositions = new HashMap<>();
+    for(int i = 0; i < postOrder.size(); i += 1) {
+      postOrderPositions.put(postOrder.get(i).getLabel(), i);
+    }
+    
+    ArrayList<Node<T>> revPostOrderMinusStart = new ArrayList<>(revPostOrder);
+    revPostOrderMinusStart.remove(root);
+    
+    while(domTreeChanged) {
+      domTreeChanged = false;
+      for(Node<T> node : revPostOrderMinusStart) {
+        ArrayList<Node<T>> preds = node.getPredecessors();
+        Node<T> newIdom = preds.get(0);
+        for(int i = 1; i < preds.size(); i += 1) {
+          Node<T> pred = preds.get(i);
+          Node<T> predIdom = pred.cloneIn(domTree).pointsToNone() ? null : pred.cloneIn(domTree).pointsTo().get(0);
+          if(predIdom == null) continue;
+          newIdom = lca(pred.cloneIn(domTree), newIdom.cloneIn(domTree), postOrderPositions);
+        }
+        Node<T> nodeIdom = node.cloneIn(domTree).pointsToNone() ? null 
+                                    : node.cloneIn(domTree).pointsTo().get(0);
+        if(nodeIdom == newIdom.cloneIn(domTree)) continue;
+        node.cloneIn(domTree).clearSuccessors();
+        node.cloneIn(domTree).pointsTo(newIdom.cloneIn(domTree));
+        domTreeChanged = true;
+      }
+    }
+    
+    root.cloneIn(domTree).clearPredecessors().clearSuccessors();
+    return domTree;
+  }
+  
+      @Deprecated
+      private static <T> Node<T> lca(Node<T> b1, 
+                          Node<T> b2, 
+                          HashMap<String, Integer> positions) {
+        Node<T> finger1 = b1;
+        Node<T> finger2 = b2;
+        while(finger1 != finger2) {
+          while(positions.get(finger1.getLabel()) 
+                  < positions.get(finger2.getLabel())) {
+            if(finger1.pointsToNone()) break;
+            finger1 = finger1.pointsTo().get(0);
+          }
+          while(positions.get(finger2.getLabel()) 
+                  < positions.get(finger1.getLabel())) {
+            if(finger2.pointsToNone()) break;
+            finger2 = finger2.pointsTo().get(0);  
+          }
+          if(finger1.pointsToNone() || finger2.pointsToNone()) break;
+        }
+        return finger1;
+      }
+}

--- a/blinky-util/src/main/java/org/spideruci/analysis/statik/controlflow/App.java
+++ b/blinky-util/src/main/java/org/spideruci/analysis/statik/controlflow/App.java
@@ -1,0 +1,11 @@
+package org.spideruci.analysis.statik.controlflow;
+
+/**
+ * Hello world!
+ *
+ */
+public class App {
+    public static void main( String[] args ) {
+        System.out.println( "Hello World!" );
+    }
+}

--- a/blinky-util/src/main/java/org/spideruci/analysis/statik/controlflow/ByteNode.java
+++ b/blinky-util/src/main/java/org/spideruci/analysis/statik/controlflow/ByteNode.java
@@ -1,0 +1,29 @@
+package org.spideruci.analysis.statik.controlflow;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.objectweb.asm.tree.analysis.Frame;
+import org.objectweb.asm.tree.analysis.Value;
+
+/**
+ * The Bytenode is an encapsulation of a symbolic stack frame in a classfile,
+ * while also storing the successors and predecessors of the stack frame, in the
+ * context of a control flow graph.
+ * @author vpalepu
+ *
+ * @param <V>
+ */
+class ByteNode<V extends Value> extends Frame {
+  Set< ByteNode<V> > successors = new HashSet< ByteNode<V> >();
+  Set< ByteNode<V> > predecessors = new HashSet< ByteNode<V> >();
+  String label = "";
+
+  public ByteNode(int nLocals, int nStack) {
+    super(nLocals, nStack);
+  }
+
+  public ByteNode(Frame src) {
+    super(src);
+  }
+}

--- a/blinky-util/src/main/java/org/spideruci/analysis/statik/controlflow/CfgBuilder.java
+++ b/blinky-util/src/main/java/org/spideruci/analysis/statik/controlflow/CfgBuilder.java
@@ -1,0 +1,128 @@
+package org.spideruci.analysis.statik.controlflow;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import java.util.Set;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.analysis.Analyzer;
+import org.objectweb.asm.tree.analysis.AnalyzerException;
+import org.objectweb.asm.tree.analysis.BasicInterpreter;
+import org.objectweb.asm.tree.analysis.BasicValue;
+import org.objectweb.asm.tree.analysis.Frame;
+import org.objectweb.asm.tree.analysis.Value;
+import org.spideruci.analysis.util.MyAssert;
+import org.spideruci.analysis.util.caryatid.ByteCodeUtil;
+
+public class CfgBuilder extends Analyzer {
+  
+  public static CfgBuilder init() {
+    return new CfgBuilder(new BasicInterpreter());
+  }
+
+  public CfgBuilder(BasicInterpreter interpreter) {
+    super(interpreter);
+  }
+  
+  protected Frame newFrame(int nLocals, int nStack) {
+    return new ByteNode<BasicValue>(nLocals, nStack);
+  }
+
+  protected Frame newFrame(Frame src) {
+    return new ByteNode<BasicValue>(src);
+  }
+
+  protected void newControlFlowEdge(int src, int dst) {
+    addControlFlowEdge(src, dst);
+  }
+
+  protected boolean newControlFlowExceptionEdge(int src, int dst) {
+    addControlFlowEdge(src, dst);
+    return true;
+  }
+
+  @SuppressWarnings("unchecked")
+  private void addControlFlowEdge(int src, int dst) {
+    ByteNode<BasicValue> s = (ByteNode<BasicValue>) getFrames()[src];
+    ByteNode<BasicValue> d = (ByteNode<BasicValue>) getFrames()[dst];
+    
+    if(s == null || d == null) {
+      return;
+    }
+    
+    s.successors.add(d);
+    if(!s.label.equals("")) {
+      MyAssert.assertThat(String.valueOf(src).equals(s.label));
+    }
+    s.label = String.valueOf(src);
+    
+    
+    d.predecessors.add(s);
+    if(!d.label.equals("")) {
+      MyAssert.assertThat(String.valueOf(dst).equals(d.label));
+    }
+    d.label = String.valueOf(dst);
+  }
+  
+  @SuppressWarnings("unchecked")
+  public Graph<String> buildGraph(String owner, MethodNode mn) throws AnalyzerException {
+    this.analyze(owner, mn);
+    AbstractInsnNode[] insnArray = mn.instructions.toArray();
+    Frame[] byte_nodes = this.getFrames();
+    checkState(insnArray.length == byte_nodes.length);
+
+    Graph<String> controlFlowGraph = Graph.create();
+    for(int i = 0; i < byte_nodes.length; i += 1) {
+      if(byte_nodes[i] == null) continue;
+      String label = ((ByteNode<Value>)byte_nodes[i]).label;
+
+      if(!String.valueOf(i).equals(label)) {
+        ((ByteNode<Value>)byte_nodes[i]).label = String.valueOf(i);
+        String errMessage = String.valueOf(insnArray[i].getOpcode() + " " +
+            insnArray.length);
+        System.err.println(errMessage);
+      }
+      
+      final int opcode = insnArray[i].getOpcode();
+      final int type = insnArray[i].getType();
+      controlFlowGraph.nowHas(label, ByteCodeUtil.opcodeToText(opcode) + '~' + type);
+      if(i == 0) {
+        controlFlowGraph.startPointsTo(controlFlowGraph.node(label));
+      }
+      
+      if(opcode == Opcodes.RETURN ||
+          opcode == Opcodes.IRETURN ||
+          opcode == Opcodes.FRETURN ||
+          opcode == Opcodes.LRETURN ||
+          opcode == Opcodes.DRETURN ||
+          opcode == Opcodes.ARETURN ||
+          opcode == Opcodes.ATHROW) {
+        Node<String> temp = controlFlowGraph.node(label);
+        controlFlowGraph.endIsPointedBy(temp);
+      }
+
+      if(opcode == Opcodes.INVOKESTATIC && 
+          ((MethodInsnNode)insnArray[i]).name.equals("exit") &&
+          ((MethodInsnNode)insnArray[i]).owner.equals("java/lang/System")) {
+        //        control_flow_graph.setEndNodePredecessors
+        //        (control_flow_graph.getNode(label));
+        controlFlowGraph.node(label).clearSuccessors();
+      }
+    }
+
+    for(int i = 0; i < byte_nodes.length; i += 1) {
+      if(byte_nodes[i] == null) continue;
+      Node<String> node = controlFlowGraph.node(String.valueOf(i));
+      Set<ByteNode<Value>> succs = ((ByteNode<Value>)byte_nodes[i]).successors;
+      for(ByteNode<Value> succ : succs) {
+        String succ_label = succ.label;
+        node.pointsTo(controlFlowGraph.node(succ_label));
+      }
+    }
+    return controlFlowGraph;
+  }
+
+}

--- a/blinky-util/src/main/java/org/spideruci/analysis/statik/controlflow/ClassCfgBuilder.java
+++ b/blinky-util/src/main/java/org/spideruci/analysis/statik/controlflow/ClassCfgBuilder.java
@@ -1,0 +1,70 @@
+package org.spideruci.analysis.statik.controlflow;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.List;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.analysis.AnalyzerException;
+
+public class ClassCfgBuilder extends ClassNode {
+  
+  private final String className;
+  
+  public ClassCfgBuilder(String className) {
+    super(Opcodes.ASM4);
+    this.className = className;
+  }
+
+  public static void main(String[] args) {
+    try {
+      ClassReader cr;
+      final String classfilePath = "/Users/vpalepu/phd-open-source/blinky/target/test-classes/org/spideruci/analysis/dynamic/tests/ControlStructureTests.class";
+      try {
+        File classfile = new File(classfilePath);
+        FileInputStream in = new FileInputStream(classfile);
+        cr = new ClassReader(in);
+      } catch(IOException ioEx ) {
+        ioEx.printStackTrace();
+        RuntimeException ioRunEx = new RuntimeException(ioEx.getMessage());
+        throw ioRunEx;
+      }
+      
+      if((cr.getAccess() & Opcodes.ACC_INTERFACE) == Opcodes.ACC_INTERFACE) {
+        return;
+      }
+      
+      final String[] classfilePathSplit = classfilePath.split("/");
+      final String className = classfilePathSplit[classfilePathSplit.length - 1];
+      ClassCfgBuilder classAd = new ClassCfgBuilder(className);
+      cr.accept(classAd, ClassReader.EXPAND_FRAMES);
+    } catch(Exception e) {
+      throw e;
+    }
+  }
+  
+  @SuppressWarnings("unchecked")
+  @Override 
+  public void visitEnd() {
+    System.out.println(className);
+    List<MethodNode> methods = this.methods;
+
+    CfgBuilder cfgBuilder = CfgBuilder.init();
+    
+    for(MethodNode method_node : methods) {
+      System.out.println("\t" + method_node.name);
+      try {
+        Graph<String> graph = cfgBuilder.buildGraph(className, method_node);
+        System.out.println(graph.toString());
+      } catch (AnalyzerException e) {
+        e.printStackTrace();
+      }
+    }
+    
+  }
+
+}

--- a/blinky-util/src/main/java/org/spideruci/analysis/statik/controlflow/ControlFlowAnalyzer.java
+++ b/blinky-util/src/main/java/org/spideruci/analysis/statik/controlflow/ControlFlowAnalyzer.java
@@ -1,0 +1,227 @@
+package org.spideruci.analysis.statik.controlflow;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.JumpInsnNode;
+import org.objectweb.asm.tree.LabelNode;
+import org.objectweb.asm.tree.LookupSwitchInsnNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.TableSwitchInsnNode;
+import org.objectweb.asm.tree.analysis.Analyzer;
+import org.objectweb.asm.tree.analysis.AnalyzerException;
+import org.objectweb.asm.tree.analysis.BasicInterpreter;
+import org.objectweb.asm.tree.analysis.BasicValue;
+import org.objectweb.asm.tree.analysis.Frame;
+import org.objectweb.asm.tree.analysis.Value;
+import org.spideruci.analysis.statik.controlflow.Graph;
+import org.spideruci.analysis.statik.controlflow.Node;
+import org.spideruci.analysis.util.caryatid.MethodPrinter;
+
+public class ControlFlowAnalyzer {
+  
+  ArrayList<AbstractInsnNode> leaders = new ArrayList<AbstractInsnNode>();
+  
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  public static Graph getCFG(String owner, MethodNode mn) throws AnalyzerException {
+
+    Analyzer analyzer = new Analyzer(new BasicInterpreter()) {
+
+      protected Frame newFrame(int nLocals, int nStack) {
+        return new ByteNode<BasicValue>(nLocals, nStack);
+      }
+
+      protected Frame newFrame(Frame src) {
+        return new ByteNode<BasicValue>(src);
+      }
+
+      protected void newControlFlowEdge(int src, int dst) {
+        add_control_flow_edge(src, dst);
+      }
+
+      protected boolean newControlFlowExceptionEdge(int src, int dst) {
+//        add_control_flow_edge(src, dst);
+        return true;
+      }
+
+      private void add_control_flow_edge(int src, int dst) {
+        ByteNode<BasicValue> s = (ByteNode<BasicValue>) getFrames()[src];
+        s.successors.add((ByteNode<BasicValue>) getFrames()[dst]);
+        if(!s.label.equals("")) {
+          checkState(String.valueOf(src).equals(s.label));
+        }
+        s.label = String.valueOf(src);
+        ByteNode<BasicValue> d = (ByteNode<BasicValue>) getFrames()[dst];
+        d.predecessors.add((ByteNode<BasicValue>) getFrames()[src]);
+        if(!d.label.equals("")) {
+          checkState(String.valueOf(dst).equals(d.label));
+        }
+        d.label = String.valueOf(dst);
+      }
+    };
+
+    analyzer.analyze(owner, mn);
+    AbstractInsnNode[] insnArray = mn.instructions.toArray();
+    Frame[] byte_nodes = analyzer.getFrames();
+    checkState(insnArray.length == byte_nodes.length);
+
+    Graph control_flow_graph = Graph.create();
+    for(int i = 0; i < byte_nodes.length; i += 1) {
+      if(byte_nodes[i] == null) continue;
+      String label = ((ByteNode<Value>)byte_nodes[i]).label;
+
+      if(!String.valueOf(i).equals(label)) {
+        ((ByteNode<Value>)byte_nodes[i]).label = String.valueOf(i);
+        String errMessage = String.valueOf(insnArray[i].getOpcode() + " " +
+            insnArray.length);
+        System.err.println(errMessage);
+      }
+      control_flow_graph.nowHas(label);
+      if(i == 0) {
+        control_flow_graph.startPointsTo
+        (control_flow_graph.node(label));
+      }
+
+      int opcode = insnArray[i].getOpcode();
+
+      if(opcode == Opcodes.RETURN ||
+          opcode == Opcodes.IRETURN ||
+          opcode == Opcodes.FRETURN ||
+          opcode == Opcodes.LRETURN ||
+          opcode == Opcodes.DRETURN ||
+          opcode == Opcodes.ARETURN ||
+          opcode == Opcodes.ATHROW) {
+        Node temp = control_flow_graph.node(label);
+        control_flow_graph.endIsPointedBy(temp);
+      }
+
+      if(opcode == Opcodes.INVOKESTATIC && 
+          ((MethodInsnNode)insnArray[i]).name.equals("exit") &&
+          ((MethodInsnNode)insnArray[i]).owner.equals("java/lang/System")) {
+        //				control_flow_graph.setEndNodePredecessors
+        //				(control_flow_graph.getNode(label));
+        control_flow_graph.node(label).clearSuccessors();
+      }
+    }
+
+    for(int i = 0; i < byte_nodes.length; i += 1) {
+      if(byte_nodes[i] == null) continue;
+      Node node = control_flow_graph.node(String.valueOf(i));
+      Set<ByteNode<Value>> succs = ((ByteNode<Value>)byte_nodes[i]).successors;
+      for(ByteNode succ : succs) {
+        String succ_label = succ.label;
+        node.pointsTo(control_flow_graph.node(succ_label));
+      }
+    }
+    return control_flow_graph;
+  }
+
+  @SuppressWarnings("unchecked")
+  public void printBasicBlocks(String owner, MethodNode mn, boolean withLeaders) 
+      throws AnalyzerException {
+    Analyzer a = new Analyzer(new BasicInterpreter()) {
+      protected Frame newFrame(int nLocals, int nStack) {
+        return new ByteNode<BasicValue>(nLocals, nStack);
+      }
+      protected Frame newFrame(Frame src) {
+        return new ByteNode<BasicValue>(src);
+      }
+      protected void newControlFlowEdge(int src, int dst) {
+        ByteNode<BasicValue> s = (ByteNode<BasicValue>) getFrames()[src];
+        s.successors.add((ByteNode<BasicValue>) getFrames()[dst]);
+        if(!s.label.equals("")) {
+          checkState(String.valueOf(src).equals(s.label));
+        }
+        s.label = String.valueOf(src);
+        ByteNode<BasicValue> d = (ByteNode<BasicValue>) getFrames()[dst];
+        d.predecessors.add((ByteNode<BasicValue>) getFrames()[src]);
+        if(!d.label.equals("")) {
+          checkState(String.valueOf(dst).equals(d.label));
+        }
+        d.label = String.valueOf(dst);
+      }
+    };
+    a.analyze(owner, mn);
+    AbstractInsnNode[] insnArray = mn.instructions.toArray();
+    Frame[] frames = a.getFrames();
+    //get the leaders
+    leaders.add(insnArray[0]); // First instruction of the method
+    System.out.println(mn.name + "() {");
+    if(withLeaders) {
+      //get the other leaders
+      findLeaders(frames, insnArray);
+      printByteCodeWithLeaders(frames, insnArray);
+    } else {
+      printByteCode(frames, insnArray);
+    }
+    System.out.println("}\n");
+  }
+
+  private void printByteCode(Frame[] frames, AbstractInsnNode[] insnArray) {
+    for(int count = 0; count < frames.length; count++) {
+      if(frames[count] != null) { // avoids deadcode
+        System.out.print("\t");
+        insnArray[count].accept(new MethodPrinter(Opcodes.ASM4));
+      }
+    }
+  }
+
+  private void printByteCodeWithLeaders(Frame[] frames, AbstractInsnNode[] insnArray) {
+    for(int count = 0; count < frames.length; count++) {
+      if(frames[count] != null) { // avoids deadcode
+        if(leaders.contains(insnArray[count])) {
+          System.out.print("LEADER:");
+        }
+        System.out.print("\t");
+        insnArray[count].accept(new MethodPrinter(Opcodes.ASM4));
+        insnArray[count].getPrevious();
+        
+      }
+    }
+  }
+
+  @SuppressWarnings({ "unchecked" })
+  private void findLeaders(Frame[] frames, AbstractInsnNode[] insnArray) {
+    for(int count = 1; count < frames.length; count++) {
+      if(frames[count] != null) { // avoids deadcode
+        switch(insnArray[count].getType()) {
+        case AbstractInsnNode.JUMP_INSN:
+          // Any instruction that immediately follows a jump
+          leaders.add(insnArray[count + 1]);
+          // Target of a jump
+          leaders.add(((JumpInsnNode)insnArray[count]).label);
+          break;
+        case AbstractInsnNode.TABLESWITCH_INSN:
+          // Any instruction that immediately follows a jump
+          leaders.add(insnArray[count + 1]);
+
+          // Targets of a switch
+          TableSwitchInsnNode node1 = (TableSwitchInsnNode)insnArray[count]; 
+          leaders.add(node1.dflt);
+          for(LabelNode labelNode : (List<LabelNode>)node1.labels) {
+            leaders.add(labelNode);
+          }
+          break;
+        case AbstractInsnNode.LOOKUPSWITCH_INSN:
+          // Any instruction that immediately follows a jump
+          leaders.add(insnArray[count + 1]);
+
+          // Targets of a switch
+          LookupSwitchInsnNode node2 = (LookupSwitchInsnNode)insnArray[count]; 
+          leaders.add(node2.dflt);
+          for(LabelNode labelNode : (List<LabelNode>)node2.labels) {
+            leaders.add(labelNode);
+          }
+          break;
+        default:
+        }
+      }
+    }
+  }
+}

--- a/blinky-util/src/main/java/org/spideruci/analysis/statik/controlflow/Graph.java
+++ b/blinky-util/src/main/java/org/spideruci/analysis/statik/controlflow/Graph.java
@@ -1,0 +1,304 @@
+package org.spideruci.analysis.statik.controlflow;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+public class Graph<G> {
+  
+  public static final String START = "START";
+  public static final String END = "END";
+  private final String uid;
+  private Node<G> startNode;
+  private Node<G> endNode;
+  private HashMap<String, Node<G>> nodes;
+  
+  public static <T> Graph<T> createEmptyGraph() {
+    return new Graph<>();
+  }
+  
+  public static <T> Graph<T> create() {
+    return create(START, END);
+  }
+  
+  public static <T> Graph<T> create(String name) {
+    return create(name, START, END);
+  }
+  
+  public static <T> Graph<T> create(String startLabel, String endLabel) {
+    return create(null, startLabel, endLabel);
+  }
+  
+  public static <T> Graph<T> create(String name, String startLabel, String endLabel) {
+    Graph<T> graph = name == null ? new Graph<T>() : new Graph<T>(name);
+    graph.startNode = Node.<T>create(startLabel, graph);
+    graph.endNode = Node.<T>create(endLabel, graph);
+    graph.nowHas(graph.startNode.and(graph.endNode));
+    return graph;
+  }
+  
+  private Graph() {
+    startNode = null;
+    endNode = null;
+    nodes = new HashMap<>();
+    uid = UUID.randomUUID().toString();
+  }
+  
+  private Graph(String name) {
+    startNode = null;
+    endNode = null;
+    nodes = new HashMap<>();
+    nodes.put(END, endNode);
+    nodes.put(START, startNode);
+    uid = name;
+  }
+  
+  public Node<G> startNode() {
+    return startNode;
+  }
+  
+  public Node<G> endNode() {
+    return endNode;
+  }
+  
+  public String uid() {
+    return uid;
+  }
+  
+  /*Util Methods*/
+
+  public Collection<Node<G>> getNodes() {
+    return nodes.values();
+  }
+  
+  public Graph<G> d0(Accumulator<G> accumulator, Consumer<Node<G>> nodeConsumer) {
+    ArrayList<Node<G>> nodes = accumulator.period();
+    nodes.forEach(nodeConsumer);
+    return this;
+  }
+
+  public Graph<G> startPointsTo(Accumulator<G> accumulator) {
+    return d0(accumulator, this::startPointsTo);
+  }
+  
+  public Graph<G> startPointsTo(Node<G> node) {
+    startNode.pointsTo(node);
+    return this;
+  }
+  
+  public Graph<G> endPointsTo(Node<G> node) {
+    endNode.pointsTo(node);
+    return this;
+  }
+  
+  public Graph<G> endIsPointedBy(Accumulator<G> accumulator) {
+    return d0(accumulator, this::endIsPointedBy);
+  }
+  
+  public Graph<G> endIsPointedBy(Node<G> node) {
+    node.pointsTo(endNode);
+    return this;
+  }
+  
+  public Graph<G> startIsPointedBy(Node<G> node) {
+    node.pointsTo(startNode);
+    return this;
+  }
+
+  public Graph<G> nowHas(Accumulator<G> accumulator) {
+    return d0(accumulator, this::nowHas);
+  }
+
+  public Graph<G> nowHas(Node<G> node) {
+    if(node == null || this.contains(node.getLabel())) 
+      return this;
+    
+    this.nodes.put(node.getLabel(), node);
+    return this;
+  }
+  
+  public Graph<G> nowHas(String nodeLabel, G nodeBody) {
+    if(nodeLabel == null || nodeLabel.isEmpty()) {
+      throw new RuntimeException("Null/Empty Node Label.");
+    }
+    this.nowHas(Node.<G>create(nodeLabel, nodeBody, this));
+    return this;
+  }
+
+  public Graph<G> nowHas(String nodeLabel) {
+    return nowHas(nodeLabel, null);
+  }
+
+  
+  public Graph<G> copy() {
+    Graph<G> copy = this.createGraphScaffold();
+    // 4. set up the successors for the rest of the nodes. 
+    for(Node<G> origNode : this.nodes.values()) {
+      if(origNode.getLabel().equals(Graph.END)) {
+        continue;
+      }
+      // "original node": the node from the original (this) graph 
+      // "new node":  the new node in the copy graph corresponding to original node 
+      // 1. get the label of the orignal node 
+      String origGraph_node_label = origNode.getLabel();
+      // 2. get the node in this graph with the matching label 
+      Node<G> newNode = copy.node(origGraph_node_label);
+      // 3. get the successors of the original node
+      ArrayList<Node<G>> origGraph_node_succs = origNode.pointsTo();
+      // 4. for each succesor of the original node
+      for(Node<G> node2 : origGraph_node_succs) {
+        // 1. get the node in this graph with the matching label
+        Node<G> newNode2 = copy.node(node2.getLabel());
+        // 2. add the obtained node as the successor of new node
+        newNode.pointsTo(newNode2);
+      }
+    }
+    return copy;
+  }
+
+  public Graph<G> reverseEdges() {
+//    Graph<G> reversedGraph = new Graph<G>(); //= this.createGraphScaffold();
+//    
+//    for(Node<G> node : this.nodes.values()) {
+//      Node<G> newNode = Node.<G>create(node.getLabel(), reversedGraph);
+//      reversedGraph.nowHas(newNode); 
+//    }
+//    
+//    reversedGraph.endNode = reversedGraph.node(END);
+//    reversedGraph.startNode = reversedGraph.node(START);
+    
+    Graph<G> reversedGraph = this.createGraphScaffold();
+    
+    reversedGraph.startNode.clearSuccessors();
+
+    for(Node<G> node : this.nodes.values()) {
+      ArrayList<Node<G>> succs = node.pointsTo();
+      if(succs == null || succs.size() == 0) continue;
+      for(Node<G> succ : succs) {
+        Node<G> temp = reversedGraph.node(succ.getLabel());
+        temp.pointsTo(reversedGraph.node(node.getLabel()));
+      }
+    }
+
+    checkState(Graph.START.equals(reversedGraph.startNode.getLabel()));
+    checkState(Graph.END.equals(reversedGraph.endNode.getLabel()));
+
+    reversedGraph.startNode = reversedGraph.node(Graph.END);
+    reversedGraph.endNode = reversedGraph.node(Graph.START);
+    
+//    Node<G> temp = reversedGraph.startNode;
+//    reversedGraph.startNode = reversedGraph.endNode;
+//    reversedGraph.endNode = temp;
+
+    checkState(Graph.END.equals(reversedGraph.startNode.getLabel()));
+    checkState(Graph.START.equals(reversedGraph.endNode.getLabel()));
+
+    //		retGraph.endNode.label = Graph.END;
+    //		retGraph.startNode.label = Graph.START;
+
+    return reversedGraph;
+  }
+  
+  public Graph<G> createGraphScaffold() {
+    Graph<G> scaffold = Graph.<G>create();
+    // 1. Create a new empty arraylist
+    scaffold.nodes = new HashMap<String, Node<G>>();
+    // 2. Copy the nodes of the original graph into the arraylist
+    for(Node<G> node : this.nodes.values()) {
+      // 1. the constructor creates bare nodes with just the labels no succs
+      Node<G> newNode = Node.<G>create(node.getLabel(), scaffold);
+      // 2. Add the newly created node in the array.
+      scaffold.nodes.put(node.getLabel(), newNode);
+    }
+    // "matching label": the string that matches the label of the original node
+    // 3. point the root of the new Graph object to a node in the node list of the new 
+    // Graph, for a node that has a matching label.
+    //      Node origGraph_root_succ = origGraph.startNode.getSuccessor(0);
+    //      Node newGraph_root_succ = this.getNode(origGraph_root_succ.label);
+    //      this.startNode.addSuccessors(newGraph_root_succ);
+    scaffold.endNode = scaffold.node(END);
+    scaffold.startNode = scaffold.node(START);
+    return scaffold;
+  }
+
+  /**
+   * @param label
+   * @return Node object - whose label.equals(input);
+   * null - if a Node object with matching label does not exist.
+   */
+  public Node<G> node(String label) {
+    return nodes.get(label);
+  }
+
+  /**
+   * @param label
+   * @return 
+   * true if there is some node n, 
+   * s.t. label.equals(n.label)
+   * false, otherwise
+   */
+  public boolean contains(String label) {
+    return nodes.containsKey(label) && nodes.get(label) != null;
+  }
+
+  public ArrayList<String> getLabels() {
+    return new ArrayList<String>(this.nodes.keySet());
+  }
+
+  public static <T> ArrayList<String> getLabels(ArrayList<Node<T>> nodes) {
+    ArrayList<String> labels = new ArrayList<String>();
+    for(Node<T> node : nodes) {
+      labels.add(node.getLabel());
+    }
+    return labels;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder strBuilder = new StringBuilder();
+    ArrayList<String> nodeLabels = this.getLabels();
+    Collections.sort(nodeLabels);
+    for(String label : nodeLabels) {
+      Node<G> node = nodes.get(label);
+      strBuilder.append(node.getPredecessorLabels()).append("-> ")
+      .append(node.getLabel())
+      .append(" ->").append(node.getSuccessorsLabels())
+      .append("\n");
+    }
+    return strBuilder.toString();
+  }
+  
+  public HashMap<String, ArrayList<String>> toMap() {
+    HashMap<String, ArrayList<String>> map = new HashMap<>();
+    for(Node<G> node: nodes.values()) {
+      if(node == null || node.pointsTo() == null || node.pointsToNone()) 
+        continue;
+      ArrayList<String> nodeStrings = new ArrayList<String>();
+      for(Node<G> succ : node.pointsTo()) {
+        if(succ == null) continue;
+        nodeStrings.add(succ.getLabel());
+      }
+      map.put(node.getLabel(), nodeStrings);
+    }
+    return map;
+  }
+
+  public void obliterate() {
+    for(String nodeLabel : this.nodes.keySet()) {
+      Node<G> node = nodes.get(nodeLabel);
+      if(node == null)
+        continue;
+      node.clearPredecessors();
+      node.clearSuccessors();
+    }
+    this.nodes.clear();
+  }
+
+  /*Graph Analysis Methods*/
+
+}

--- a/blinky-util/src/main/java/org/spideruci/analysis/statik/controlflow/Node.java
+++ b/blinky-util/src/main/java/org/spideruci/analysis/statik/controlflow/Node.java
@@ -1,0 +1,256 @@
+package org.spideruci.analysis.statik.controlflow;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+
+import org.spideruci.analysis.util.caryatid.Helper;
+
+import com.google.common.base.Preconditions;
+
+public class Node<T> {
+  /**
+   * Nodes being pointed to by this node.
+   */
+  private HashSet<Node<T>> successors;
+  /**
+   * Nodes that are pointing to this node.
+   */
+  private HashSet<Node<T>> predecessors;
+  /**
+   * This is a unique Identifier for the Node
+   */
+  private String label;
+  private final T body;
+  /**
+   * This is the Graph that contains this node.
+   * A given node may be present in only one node.
+   */
+  private Graph<T> containerGraph;
+
+  public static <N> Node<N> create(String label, Graph<N> containerGraph) {
+    Node<N> node = new Node<N>(label);
+    node.setContainerGraph(containerGraph);
+    return node;
+  }
+  
+  public static <N> Node<N> create(String label, N body, Graph<N> containerGraph) {
+    Node<N> node = new Node<N>(label, body);
+    node.setContainerGraph(containerGraph);
+    return node;
+  }
+
+  private Node(String label) {
+    this.successors = new LinkedHashSet<Node<T>>();
+    this.predecessors = new LinkedHashSet<Node<T>>();
+    this.label = new String(label);
+    this.body = null;
+  }
+
+  private Node(String label, T _body) {
+    this.successors = new HashSet<Node<T>>();
+    this.predecessors = new HashSet<Node<T>>();
+    this.label = new String(label);
+    this.body = _body;
+  }
+  
+  public Accumulator<T> and(Node<T> node) {
+    return Accumulator.<T>create().and(this).and(node);
+  }
+  
+  public Node<T> clearSuccessors() {
+    if(this.successors == null) 
+      return this;
+    
+    for(Node<T> succ : this.successors) {
+      succ.predecessors.remove(this);
+    }
+    this.successors.clear();
+    return this;
+  }
+  
+  public Node<T> clearPredecessors() {
+    if(this.predecessors == null)
+      return this;
+    
+    for(Node<T> pred : this.predecessors) {
+      pred.successors.remove(this);
+    }
+    
+    this.predecessors.clear();
+    return this;
+  }
+  
+  public Node<T> pointsTo(Node<T> node) {
+    if(node == null) return this;
+    this.successors.add(node);
+    node.predecessors.add(this);
+    return this;
+  }
+  
+  public Node<T> pointsTo(Accumulator<T> accumulator) {
+    ArrayList<Node<T>> nodes = accumulator.period();
+    if(nodes == null || nodes.size() == 0) return this;
+    for(Node<T> node : nodes) {
+      pointsTo(node);
+    }
+    return this;
+  }
+
+  public ArrayList<Node<T>> pointsTo() {
+    if(successors == null) return Helper.Collections2.emptyArrayList();
+    ArrayList<Node<T>> succs = new ArrayList<Node<T>>(successors);
+    return succs;
+  }
+
+  public int getSuccessorsSize() {
+    if(this.successors == null) {
+      return 0;
+    }
+    return this.successors.size();
+  }
+
+  public ArrayList<Node<T>> getPredecessors() {
+    if(predecessors == null) return Helper.Collections2.emptyArrayList();
+    ArrayList<Node<T>> preds = new ArrayList<Node<T>>(predecessors);
+    return preds;
+  }
+  
+  /**
+   * Assumes that this node is part of a TREE and not a GRAPH,
+   * i.e. the node has at most one predecessor, and not more 
+   * than one. If it has zero predecessor, then it is a root 
+   * node of this tree.
+   * @return 
+   * parent of this node; <br>
+   * null if this node has no parent;
+   */
+  public Node<T> getParentInTree() {
+    ArrayList<Node<T>> preds = this.getPredecessors();
+    Preconditions.checkState(preds.size() <= 1);
+    
+    Node<T> pred = preds.isEmpty() ? null : preds.get(0);
+    return pred;
+  }
+
+  public int getPredecessorsSize() {
+    if(this.predecessors == null) {
+      return 0;
+    }
+    return this.predecessors.size();
+  }
+  
+  public boolean isPointedByNone() {
+    return predecessors.isEmpty();
+  }
+  
+  public boolean pointsToNone() {
+    return successors.isEmpty();
+  }
+
+  public ArrayList<String> getPredecessorLabels() {
+    ArrayList<String> predLabels = new ArrayList<String>();
+    for(Node<T> pred : this.predecessors) {
+      predLabels.add(pred.getLabel());
+    }
+    return predLabels;
+  }
+  
+  public ArrayList<String> getSuccessorsLabels() {
+    ArrayList<String> succLabels = new ArrayList<String>();
+    for(Node<T> pred : this.successors) {
+      succLabels.add(pred.getLabel());
+    }
+    return succLabels;
+  }
+
+  public boolean containsSuccessor(String label) {
+    if(successors == null) return false;
+    for(Node<T> succ : this.successors) {
+      if(succ.equals(label)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public boolean containsPredecessor(String label) {
+    if(predecessors == null) return false;
+    for(Node<T> pred : this.predecessors) {
+      if(pred.equals(label)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder strBuilder = new StringBuilder();
+    strBuilder.append(this.getLabel());
+    
+    final T body = this.getBody();
+    if(body != null) {
+      strBuilder.append(":").append(body.toString());
+    }
+    
+    return strBuilder.toString();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if(!(obj instanceof Node<?>)) {
+      return false;
+    }
+    
+    if(obj == this) {
+      return true;
+    }
+    
+    @SuppressWarnings("unchecked")
+    Node<T> node = (Node<T>)obj; 
+    
+    if(node.getLabel().equals(label)
+        && node.containerGraph.uid() == this.containerGraph.uid()) {
+      return true;
+    }
+    
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int code = 37;
+    code += this.getLabel().hashCode() * 17;
+    code += this.containerGraph.uid().hashCode() * 17;
+    return code;
+  }
+
+  public String getLabel() {
+    if(this.label == null && this.body == null) {
+      return "null";
+    }
+    else if(this.label == null && this.body != null) {
+      return this.body.toString();
+    } else {
+      return this.label;
+    }
+  }
+  
+  public Node<T> cloneIn(Graph<T> graph) {
+    return graph.node(this.getLabel());
+  }
+
+  public Graph<T> getContainerGraph() {
+    return this.containerGraph;
+  }
+  
+  public void setContainerGraph(Graph<T> graph) {
+     containerGraph = graph;
+  }
+
+  public T getBody() {
+    return this.body;
+  }
+
+}

--- a/blinky-util/src/main/java/org/spideruci/analysis/statik/instrumentation/ControlDepAdapter.java
+++ b/blinky-util/src/main/java/org/spideruci/analysis/statik/instrumentation/ControlDepAdapter.java
@@ -1,0 +1,111 @@
+package org.spideruci.analysis.statik.instrumentation;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.analysis.AnalyzerException;
+import org.spideruci.analysis.statik.controlflow.Algorithms;
+import org.spideruci.analysis.statik.controlflow.ControlFlowAnalyzer;
+import org.spideruci.analysis.statik.controlflow.Graph;
+
+public class ControlDepAdapter extends ClassNode {
+  private String className;
+  private ClassVisitor cv;
+  private boolean debug;
+  public ControlDepAdapter(ClassVisitor cv, String className, boolean debug) {
+    super(Opcodes.ASM4);
+    this.className = className;
+    this.cv = cv;
+    this.debug = debug;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override 
+  public void visitEnd() {
+    List<MethodNode> methods = this.methods;
+
+    if(debug) {
+      System.out.println(this.className);
+    }
+
+    for(MethodNode method_node : methods) {
+      Graph domTree = null;
+      Graph cfg = null;
+      HashMap<String, ArrayList<String>> imm_post_dominators = null; 
+      try {
+        cfg = ControlFlowAnalyzer.getCFG(this.className, method_node);
+        if(cfg == null) {
+          return;
+        }
+        if(debug) {
+          System.out.println(method_node.name);
+          System.out.println(cfg);
+        }
+        domTree = Algorithms.computeDomTree(cfg.reverseEdges().startNode());
+        imm_post_dominators = domTree.toMap();
+      } catch (AnalyzerException e) {
+        e.printStackTrace();
+      } catch (NullPointerException | StackOverflowError nullExp) {
+        imm_post_dominators = null;
+      }
+
+      AbstractInsnNode[] insns = method_node.instructions.toArray();
+      for(int i = 0 ; i < insns.length; i ++) {
+        String ipd;
+        if(imm_post_dominators != null 
+            && imm_post_dominators.containsKey(String.valueOf(i))) {
+          ipd = imm_post_dominators.get(String.valueOf(i)).get(0);
+        } else {
+          ipd = "END";
+        }
+
+        while(true) {
+          boolean _break = false;
+          int index;
+          try {
+            index = Integer.parseInt(ipd);
+          } catch(NumberFormatException ex) {
+            break;
+          }
+          int type = insns[index].getType();
+          switch(type) {
+          case AbstractInsnNode.LABEL: 
+          case AbstractInsnNode.FRAME: 
+          case AbstractInsnNode.LINE:
+            ipd = imm_post_dominators == null ? "END" : imm_post_dominators.get(String.valueOf(index)).get(0);
+            break;
+          default:
+            _break = true;
+          }
+          if(_break) break;
+        }
+        MethodNode mn = get_printlog_insn_nodes("palepu@bytecode@" + i + "@ipd@" + ipd);
+        method_node.instructions.insertBefore(insns[i], mn.instructions);
+      }
+    }
+    accept(cv);
+  }
+
+  @SuppressWarnings({ "unused" })
+  private MethodNode getMethodnode(String method_name) {
+    List<MethodNode> methods = this.methods; 
+    for(MethodNode mn : methods) {
+      if(mn.name.equals(method_name)) {
+        return mn;
+      }
+    }
+    return null;
+  }
+
+  private MethodNode get_printlog_insn_nodes(String log_message) {
+    MethodNode mn = new MethodNode();
+    mn.visitLdcInsn(log_message);
+    return mn;
+  }
+}

--- a/blinky-util/src/test/java/org/spideruci/analysis/statik/controlflow/BottomUpTopologicalSortTest.java
+++ b/blinky-util/src/test/java/org/spideruci/analysis/statik/controlflow/BottomUpTopologicalSortTest.java
@@ -1,0 +1,101 @@
+package org.spideruci.analysis.statik.controlflow;
+
+import java.util.ArrayList;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.spideruci.jump.Graphs;
+import org.spideruci.jump.Traversal;
+
+public class BottomUpTopologicalSortTest {
+  
+  private void computeTopologyAndExpect(
+      // given
+      Graph<Integer> flowGraph, 
+      Traversal<Node<Integer>> expectedBottomUpTopology) {
+    
+    // when
+    ArrayList<Node<Integer>> bottomUpTopology = 
+        Algorithms.bottomUpTopologicalSort(flowGraph);
+    
+    // then
+    expectedBottomUpTopology.compareWith(bottomUpTopology);
+  }
+
+  @Test
+  public void testJustStartAndEnd() {
+    Graph<Integer> flow = Graphs.justStartAndEnd();
+    
+    Traversal<Node<Integer>> expectedBottomUpTopology = 
+        Traversal.add(flow.endNode())
+        .and(flow.startNode());
+    
+    computeTopologyAndExpect(flow, expectedBottomUpTopology);
+  }
+  
+  @Ignore
+  @Test
+  public void testStartAndEndInACycle() {
+    Graph<Integer> flow = Graphs.startAndEndWithACycle();
+    
+    Algorithms.collapseStrongComponents(flow);
+    ArrayList<Node<Integer>> bottomUpTopology = 
+        Algorithms.bottomUpTopologicalSort(flow);
+    
+    System.out.println(bottomUpTopology);
+    
+    Traversal<Node<Integer>> expectedBottomUpTopology = 
+        Traversal.addInAnyOrder(flow.startNode().and(flow.endNode()).period());
+    
+    computeTopologyAndExpect(flow, expectedBottomUpTopology);
+  }
+  
+  @Test
+  public void testSimpleIfStructure() {
+    Graph<Integer> flow = Graphs.simpleIfStructure();
+    
+    Traversal<Node<Integer>> expectedBottomUpTopology = 
+        Traversal.add(flow.endNode())
+        .and(flow.node("next"))
+        .and(flow.node("join"))
+        .and(flow.node("then"))
+        .and(flow.node("branch"))
+        .and(flow.startNode());
+    
+    computeTopologyAndExpect(flow, expectedBottomUpTopology);
+  }
+  
+  @Test
+  public void testSimpleIfElseStructure() {
+    Graph<Integer> flow = Graphs.simpleIfElseStructure();
+    
+    Traversal<Node<Integer>> expectedBottomUpTopology = 
+        Traversal.add(flow.endNode())
+        .and(flow.node("next"))
+        .and(flow.node("join"))
+        .inAnyOrder(
+            flow.node("then")
+            .and(flow.node("else"))
+            .period())
+        .and(flow.node("branch"))
+        .and(flow.startNode());
+    
+    computeTopologyAndExpect(flow, expectedBottomUpTopology);
+  }
+  
+  @Test
+  public void testBinaryTree() {
+    Graph<Integer> flow = Graphs.simpleBinaryTree();
+    
+    Traversal<Node<Integer>> expectedBottomUpTopology = 
+        Traversal.addInAnyOrder(
+            flow.node("1").and(flow.node("4")).and(flow.node("6")).andAlso(flow.endNode()))
+        .inAnyOrder(
+            flow.node("5").and(flow.node("2")).period())
+        .and(flow.node("3"))
+        .and(flow.startNode());
+    
+    computeTopologyAndExpect(flow, expectedBottomUpTopology);
+  }
+
+}

--- a/blinky-util/src/test/java/org/spideruci/analysis/statik/controlflow/CollapsingStrongComponentsTest.java
+++ b/blinky-util/src/test/java/org/spideruci/analysis/statik/controlflow/CollapsingStrongComponentsTest.java
@@ -1,0 +1,155 @@
+package org.spideruci.analysis.statik.controlflow;
+
+import static org.junit.Assert.*;
+import static org.spideruci.analysis.statik.controlflow.StronglyConnectedComponentsTest.assertExpectedAndActualLeadersAreSame;
+
+import java.util.HashMap;
+
+import org.junit.Test;
+import org.spideruci.jump.GraphAssertions;
+import org.spideruci.jump.Graphs;
+
+public class CollapsingStrongComponentsTest {
+
+  @Test
+  public void collapsingStartAndEndWithCycleShouldLeaveStartAlone() {
+    // given
+    Graph<Integer> flowGraph = Graphs.startAndEndWithACycle();
+    Node<Integer> startNode = flowGraph.startNode();
+    Node<Integer> endNode = flowGraph.endNode();
+
+    // and
+    HashMap<Node<Integer>, Node<Integer>> expectedLeaders = new HashMap<>();
+    expectedLeaders.put(startNode, startNode);
+    expectedLeaders.put(endNode, startNode);
+
+    // when
+    HashMap<Node<Integer>, Node<Integer>> actualLeaders =
+        Algorithms.collapseStrongComponents(flowGraph);
+
+    // then
+    assertExpectedAndActualLeadersAreSame(actualLeaders, expectedLeaders);
+
+    // and
+    assertTrue(startNode.pointsToNone() && startNode.isPointedByNone());
+    assertTrue(endNode.pointsToNone() && endNode.isPointedByNone());
+  }
+
+  @Test
+  public void collapsingSscWithThreeNodesShouldLeaveStartAlone() {
+    // given
+    Graph<Integer> flowGraph = Graphs.threeNodesWithACycle();
+
+    // and
+    HashMap<Node<Integer>, Node<Integer>> expectedLeaders = new HashMap<>();
+
+    Node<Integer> startNode = flowGraph.startNode();
+    Node<Integer> endNode = flowGraph.endNode();
+    Node<Integer> node = flowGraph.node("node");
+
+    expectedLeaders.put(startNode, startNode);
+    expectedLeaders.put(node, startNode);
+    expectedLeaders.put(endNode, startNode);
+
+    // when
+    HashMap<Node<Integer>, Node<Integer>> actualLeaders = 
+        Algorithms.collapseStrongComponents(flowGraph);
+
+    // then
+    assertTrue(startNode.pointsToNone() && startNode.isPointedByNone());
+    assertTrue(endNode.pointsToNone() && endNode.isPointedByNone());
+    assertTrue(node.pointsToNone() && node.isPointedByNone());
+
+    // and
+    assertExpectedAndActualLeadersAreSame(actualLeaders, expectedLeaders);
+  }
+  
+  @Test
+  public void collapseLoopBodyIntoHeader() {
+    // given
+    Graph<Integer> flowGraph = Graphs.simpleLoopStruture();
+    
+    Node<Integer> head = flowGraph.node("head");
+    Node<Integer> body = flowGraph.node("body");
+    Node<Integer> tail = flowGraph.node("tail");
+    
+    System.out.println(flowGraph);
+    
+    // and
+    HashMap<Node<Integer>, Node<Integer>> expectedLeaders = new HashMap<>();
+    
+    expectedLeaders.put(flowGraph.startNode(), flowGraph.startNode());
+    expectedLeaders.put(head, head);
+    expectedLeaders.put(body, head);
+    expectedLeaders.put(tail, tail);
+    expectedLeaders.put(flowGraph.endNode(), flowGraph.endNode());
+    
+    // when
+    HashMap<Node<Integer>, Node<Integer>> actualLeaders = 
+        Algorithms.collapseStrongComponents(flowGraph);
+    
+    // then
+    GraphAssertions.assert1pointsTo2(Graph.START, "head", flowGraph);
+    GraphAssertions.assert1pointsTo2("head", "tail", flowGraph);
+    GraphAssertions.assert1pointsTo2("tail", Graph.END, flowGraph);
+    GraphAssertions.assertNodeIsSolitary(body);
+    
+    // and
+    assertExpectedAndActualLeadersAreSame(actualLeaders, expectedLeaders);
+    
+    System.out.println(flowGraph);
+  }
+
+  @Test
+  public void collapseShouldJoinStart_One_Nine_EightAndLeaveRestAlone() {
+    // given
+    Graph<Integer> flowGraph = Graphs.threeStronglyConnectedComponents();
+    Node<Integer> node1 = flowGraph.node("1");
+    Node<Integer> node8 = flowGraph.node("8");
+    Node<Integer> node9 = flowGraph.node("9");
+    
+    System.out.println(flowGraph + "\n");
+    
+    // and
+    HashMap<Node<Integer>, Node<Integer>> expectedLeaders = new HashMap<>();
+
+    expectedLeaders.put(flowGraph.startNode(), flowGraph.startNode());
+
+    expectedLeaders.put(node1, node1);
+    expectedLeaders.put(flowGraph.node("4"), node1);
+    expectedLeaders.put(flowGraph.node("7"), node1);
+
+    expectedLeaders.put(node8, node8);
+    expectedLeaders.put(flowGraph.node("2"), node8);
+    expectedLeaders.put(flowGraph.node("5"), node8);
+
+    expectedLeaders.put(node9, node9);
+    expectedLeaders.put(flowGraph.node("3"), node9);
+    expectedLeaders.put(flowGraph.node("6"), node9);
+
+    // when
+    HashMap<Node<Integer>, Node<Integer>> actualLeaders = 
+        Algorithms.collapseStrongComponents(flowGraph);
+
+    // then
+    GraphAssertions.assert1pointsTo2(Graph.START, "1", flowGraph);
+    GraphAssertions.assert1pointsTo2("1", "9", flowGraph);
+    GraphAssertions.assert1pointsTo2("9", "8", flowGraph);
+    
+    // and
+    GraphAssertions.assertNodeIsSolitary(flowGraph.node("4"));
+    GraphAssertions.assertNodeIsSolitary(flowGraph.node("7"));
+    
+    GraphAssertions.assertNodeIsSolitary(flowGraph.node("2"));
+    GraphAssertions.assertNodeIsSolitary(flowGraph.node("5"));
+    
+    GraphAssertions.assertNodeIsSolitary(flowGraph.node("3"));
+    GraphAssertions.assertNodeIsSolitary(flowGraph.node("6"));
+    
+    // and
+    assertExpectedAndActualLeadersAreSame(actualLeaders, expectedLeaders);
+    
+    System.out.println(flowGraph);
+  }
+
+}

--- a/blinky-util/src/test/java/org/spideruci/analysis/statik/controlflow/DomTreeTest.java
+++ b/blinky-util/src/test/java/org/spideruci/analysis/statik/controlflow/DomTreeTest.java
@@ -1,0 +1,189 @@
+package org.spideruci.analysis.statik.controlflow;
+
+import static org.junit.Assert.*;
+import static org.spideruci.jump.GraphAssertions.*;
+
+import java.util.function.BiConsumer;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.spideruci.jump.Graphs;
+
+public class DomTreeTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+  
+  @Test
+  public void shouldThrowExceptionWithNullFlowGraph() {
+    // given
+    Graph<Integer> flowGraph = null;
+    
+    // then
+    thrown.expect(IllegalArgumentException.class);
+    
+    //when
+    Algorithms.getDominatorTree(flowGraph);
+  }
+  
+  @Test
+  public void shouldReturnThrowupWhenFlowGraphIsEmpty() {
+    // given
+    Graph<Integer> flowGraph = Graph.createEmptyGraph();
+    
+    // then
+    thrown.expect(IllegalArgumentException.class);
+    
+    //when
+    Algorithms.getDominatorTree(flowGraph);
+  }
+  
+  @Test
+  public void shouldReturnthrowUpWithNullStartNode() {
+    // given
+    Graph<Integer> flowGraph = Graph.create();
+    
+    // then
+    thrown.expect(IllegalArgumentException.class);
+    
+    //when
+    Algorithms.getDominatorTree(flowGraph);
+  }
+  
+  @Test
+  public void endShouldPointToStartInGraphWithNoOtherNodes() {
+    // given
+    Graph<Integer> flowGraph = Graphs.justStartAndEnd();
+    
+    System.out.println(flowGraph);
+    
+    //when
+    Graph<Integer> domTree = Algorithms.getDominatorTree(flowGraph);
+    
+    System.out.println(domTree);
+    
+    //then
+    assertTrue(domTree.node(Graph.START).pointsTo().contains(domTree.node(Graph.END)));
+  }
+  
+  @Test
+  public void testDomTreeForSimpleIfStructure() {
+    // given
+    Graph<Integer> flowGraph = Graphs.simpleIfStructure();
+    
+    System.out.println(flowGraph);
+    
+    //when
+    Graph<Integer> domTree = Algorithms.getDominatorTree(flowGraph);
+    
+    System.out.println(domTree);
+    
+    //then
+    assert1pointsTo2(Graph.START, Graph.END, domTree);
+    assert1pointsTo2(Graph.START, "branch", domTree);
+    assert1pointsTo2("branch", "then", domTree);
+    assert1pointsTo2("branch", "join", domTree);
+    assert1pointsTo2("join", "next", domTree);
+    assert1doesNotPointTo2("next", Graph.END, domTree);
+    assert1doesNotPointTo2(Graph.START, "join", domTree);
+    assert1doesNotPointTo2(Graph.START, "next", domTree);
+  }
+  
+  @Test
+  public void testDomTreeForSimpleIfElseStructure() {
+    // given
+    Graph<Integer> flowGraph = Graphs.simpleIfElseStructure();
+    
+    System.out.println(flowGraph);
+    
+    //when
+    Graph<Integer> domTree = Algorithms.getDominatorTree(flowGraph);
+    
+    System.out.println(domTree);
+    
+    //then
+    assert1pointsTo2(Graph.START, Graph.END, domTree);
+    assert1pointsTo2(Graph.START, "branch", domTree);
+    assert1pointsTo2("branch", "then", domTree);
+    assert1pointsTo2("branch", "else", domTree);
+    assert1pointsTo2("branch", "join", domTree);
+    assert1pointsTo2("join", "next", domTree);
+    assert1doesNotPointTo2("next", Graph.END, domTree);
+    assert1doesNotPointTo2(Graph.START, "join", domTree);
+    assert1doesNotPointTo2(Graph.START, "next", domTree);
+  }
+  
+  @Test
+  public void testForSimpleLoopStructure() {
+    // given
+    Graph<Integer> flowGraph = Graphs.simpleLoopStruture();
+    
+    System.out.println(flowGraph);
+    
+    //when
+    Graph<Integer> domTree = Algorithms.getDominatorTree(flowGraph);
+    
+    System.out.println(domTree);
+    
+    //then
+    assert1pointsTo2(Graph.START, Graph.END, domTree);
+    assert1pointsTo2(Graph.START, "head", domTree);
+    assert1pointsTo2("head", "body", domTree);
+    assert1pointsTo2("head", "tail", domTree);
+    assert1doesNotPointTo2("head", Graph.END, domTree);
+    assert1doesNotPointTo2(Graph.START, "tail", domTree);
+  }
+  
+  /**
+   * <a href="http://pages.cs.wisc.edu/~fischer/cs701.f08/lectures/Lecture19.4up.pdf">http://pages.cs.wisc.edu/~fischer/cs701.f08/lectures/Lecture19.4up.pdf
+   */
+  @Test
+  public void testDomTreeFischerLectureExample() {
+ // given
+    Graph<Integer> flowGraph = Graphs.fisher();
+    
+    System.out.println(flowGraph);
+    
+    //when
+    Graph<Integer> domTree = Algorithms.getDominatorTree(flowGraph);
+    
+    //then
+    System.out.println(domTree);
+    
+    assert1pointsTo2(Graph.START, "a", domTree);
+    assert1pointsTo2("a", "b", domTree);
+    assert1pointsTo2("a", "c", domTree);
+    assert1pointsTo2("a", "d", domTree);
+    assert1pointsTo2("d", "e", domTree);
+    assert1pointsTo2("e", "f", domTree);
+    assert1pointsTo2("f", Graph.END, domTree);
+  }
+  
+  @Test
+  public void testPostDomTreeFischerLectureExample() {
+    // given
+    Graph<Integer> flowGraph = Graphs.fisher();
+
+    Graph<Integer> revFlowGraph = flowGraph.reverseEdges();
+    
+    System.out.println(revFlowGraph);
+
+    //when
+    Graph<Integer> domTree = Algorithms.getDominatorTree(revFlowGraph);
+
+    //then
+    System.out.println(domTree);
+
+    assert1pointsTo2("a", Graph.START, domTree);
+    assert1pointsTo2("d", "a", domTree);
+    assert1pointsTo2("d", "b", domTree);
+    assert1pointsTo2("d", "c", domTree);
+    assert1pointsTo2("e", "d", domTree);
+    assert1pointsTo2("f", "e", domTree);
+    assert1pointsTo2(Graph.END, "f", domTree);
+  }
+  
+
+
+}

--- a/blinky-util/src/test/java/org/spideruci/analysis/statik/controlflow/LcaTest.java
+++ b/blinky-util/src/test/java/org/spideruci/analysis/statik/controlflow/LcaTest.java
@@ -1,0 +1,216 @@
+package org.spideruci.analysis.statik.controlflow;
+
+import static org.junit.Assert.*;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class LcaTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void firstNullInputsShouldThrowIllegalStateException() {
+    //given
+    Node<Integer> n1 = null;
+    Node<Integer> n2 = Node.create("node2", null);
+
+    // then
+    thrown.expect(IllegalStateException.class);
+
+    // when
+    Algorithms.lowestCommonAncestor(n1, n2);
+  }
+
+  @Test
+  public void secondNullInputsShouldThrowIllegalStateException() {
+    //given
+    Node<Integer> n1 = Node.create("node2", null);
+    Node<Integer> n2 = null;
+
+    // then
+    thrown.expect(IllegalStateException.class);
+
+    // when
+    Algorithms.lowestCommonAncestor(n1, n2);
+  }
+
+  @Test
+  public void bothNullInputsShouldThrowIllegalStateException() {
+    //given
+    Node<Integer> n1 = null;
+    Node<Integer> n2 = null;
+
+    // then
+    thrown.expect(IllegalStateException.class);
+
+    // when
+    Algorithms.lowestCommonAncestor(n1, n2);
+  }
+
+  @Test
+  public void shouldThrowIllegalStateExceptionWithNodesFromDifferentTrees() {
+    //given
+    Node<Integer> n1 = Node.create("node1", Graph.createEmptyGraph());
+    Node<Integer> n2 = Node.create("node2", Graph.createEmptyGraph());
+
+    // then
+    thrown.expect(IllegalStateException.class);
+
+    // when
+    Algorithms.lowestCommonAncestor(n1, n2);
+  }
+
+  @Test
+  public void shouldThrow_NoExceptions_With_Treeless_NonNull_Nodes() {
+    //given
+    Node<Integer> n1 = Node.create("node1", null);
+    Node<Integer> n2 = Node.create("node2", null);
+
+    // when
+    Algorithms.lowestCommonAncestor(n1, n2);
+  }
+
+  @Test
+  public void shouldReturnInputNodeWhenPassedAsBothArgs() {
+    //given
+    Node<Integer> n1 = Node.create("node1", null);
+    
+    // when
+    Node<Integer> lca = Algorithms.lowestCommonAncestor(n1, n1);
+
+    // then
+    assertEquals(n1, lca);
+  }
+
+  @Test
+  public void shouldReturnRootWith_BalancedThreeElementBinaryTree() {
+    //given
+    Graph<Integer> tree = Graph.create();
+    Node<Integer> n1 = Node.create("node1", tree);
+    Node<Integer> n2 = Node.create("node2", tree);
+    tree.nowHas(n1.and(n2));
+    // ...and
+    tree.startNode().pointsTo(n1);
+    tree.startNode().pointsTo(n2);
+    
+    // when
+    Node<Integer> lca = Algorithms.lowestCommonAncestor(n1, n2);
+
+    // then
+    assertEquals(tree.startNode(), lca);
+  }
+  
+  @Test
+  public void shouldReturnN1With_UnBalancedThreeElementBinaryTree() {
+    //given
+    Graph<Integer> tree = Graph.create();
+    Node<Integer> n1 = Node.create("n1", tree);
+    Node<Integer> n2 = Node.create("n2", tree);
+    tree.nowHas(n1.and(n2));
+    // ...and
+    tree.startNode().pointsTo(n1);
+    n1.pointsTo(n2);
+    
+    // when
+    Node<Integer> lca = Algorithms.lowestCommonAncestor(n1, n2);
+
+    // then
+    assertEquals(n1, lca);
+  }
+  
+  @Test
+  public void shouldReturnRootWith_UnbalancedTree() {
+    //given
+    Graph<Integer> tree = Graph.create();
+    
+    Node<Integer> n1 = Node.create("n1", tree);
+    Node<Integer> n2 = Node.create("n2", tree);
+    Node<Integer> n3 =Node.create("n3", tree);
+    Node<Integer> n4 =Node.create("n4", tree);
+    Node<Integer> n5 =Node.create("n5", tree);
+    
+    tree.nowHas(n1.and(n2).and(n3).and(n4).and(n5));
+    // ...and
+    tree.startNode().pointsTo(n1);
+    tree.startNode().pointsTo(n2.pointsTo(n3.pointsTo(n4.pointsTo(n5))));
+    
+    // when
+    Node<Integer> lca = Algorithms.lowestCommonAncestor(n5, n1);
+
+    // then
+    assertEquals(tree.startNode(), lca);
+  }
+  
+  @Test
+  public void shouldReturnRootWith_NaryTree() {
+    //given
+    Graph<Integer> tree = Graph.create();
+    @SuppressWarnings("unchecked")
+    Node<Integer>[] nodes = new Node[] {
+        Node.create("n1", tree),
+        Node.create("n2", tree),
+        Node.create("n3", tree),
+        };
+    tree.nowHas(Accumulator.<Integer>create().with(nodes));
+    // ...and
+    tree.startNode().pointsTo(nodes[0]);
+    tree.startNode().pointsTo(nodes[1]);
+    tree.startNode().pointsTo(nodes[2]);
+    
+    // when
+    Node<Integer> lca = Algorithms.lowestCommonAncestor(nodes[2], nodes[0]);
+
+    // then
+    assertEquals(tree.startNode(), lca);
+  }
+  
+  @Test
+  public void shouldReturnN3With_NaryTree_WithLongNeck() {
+    //given
+    Graph<Integer> tree = Graph.create();
+    
+    Node<Integer> n1 = Node.create("n1", tree);
+    Node<Integer> n2 = Node.create("n2", tree);
+    Node<Integer> n3 =Node.create("n3", tree);
+    Node<Integer> n4 =Node.create("n4", tree);
+    Node<Integer> n5 =Node.create("n5", tree);
+    Node<Integer> n6 =Node.create("n6", tree);
+    
+    tree.nowHas(n1.and(n2).and(n3).and(n4).and(n5).and(n6));
+    // ...and
+    tree.startNode().pointsTo(n1.and(n2).and(n3));
+    
+    n3.pointsTo(n6.and(n4.pointsTo(n5)));
+    
+    // when
+    Node<Integer> lca = Algorithms.lowestCommonAncestor(n6, n5);
+
+    // then
+    assertEquals(n3, lca);
+  }
+  
+  @Test
+  public void shouldThrowIllegalStateExceptionWhenNodesNotInTree() {
+    //given
+    Graph<Integer> tree = Graph.create();
+    
+    Node<Integer> n1 = Node.create("n1", tree);
+    Node<Integer> n2 = Node.create("n2", tree);
+    
+    tree.nowHas(n1.and(n2));
+    // ...and
+    tree.startNode().pointsTo(n1.and(n2));
+    tree.endIsPointedBy(n1.and(n2));
+    
+    //then
+    thrown.expect(IllegalStateException.class);
+    
+    // when
+    Algorithms.lowestCommonAncestor(n1, tree.endNode());
+  }
+
+}

--- a/blinky-util/src/test/java/org/spideruci/analysis/statik/controlflow/PostOrderTraversalTest.java
+++ b/blinky-util/src/test/java/org/spideruci/analysis/statik/controlflow/PostOrderTraversalTest.java
@@ -1,0 +1,126 @@
+package org.spideruci.analysis.statik.controlflow;
+
+import java.util.ArrayList;
+
+import org.junit.Test;
+import org.spideruci.jump.Graphs;
+import org.spideruci.jump.Traversal;
+
+public class PostOrderTraversalTest {
+  
+  private void traverseAndExpect(
+    /*given:*/
+    Node<Integer> root, 
+    Traversal<Node<Integer>> expectedTraversal) {
+    
+    // when
+    ArrayList<Node<Integer>> actualTraversal = Algorithms.traversePostOrder(root);
+    
+    // then
+    expectedTraversal.compareWith(actualTraversal);
+  }
+  
+  @Test
+  public void nullRootShouldReturnEmptyTraversal() {
+    Node<Integer> root = null;
+    Traversal<Node<Integer>> expectedTraversal = new Traversal<>();
+    
+    traverseAndExpect(root, expectedTraversal);
+  }
+  
+  @Test
+  public void testJustStartAndEnd() {
+    Graph<Integer> flow = Graphs.justStartAndEnd();
+    
+    Traversal<Node<Integer>> expectedTraversal = 
+        Traversal.add(flow.endNode()).and(flow.startNode());
+    
+    traverseAndExpect(flow.startNode(), expectedTraversal);
+  }
+  
+  @Test
+  public void testIfStructure() {
+    Graph<Integer> flow = Graphs.simpleIfStructure();
+    
+    Traversal<Node<Integer>> expectedTraversal = 
+        Traversal.add(flow.endNode())
+        .and(flow.node("next"))
+        .and(flow.node("join"))
+        .and(flow.node("then"))
+        .and(flow.node("branch"))
+        .and(flow.startNode());
+    
+    traverseAndExpect(flow.startNode(), expectedTraversal);
+  }
+  
+  @Test
+  public void testIfElseStructure() {
+    Graph<Integer> flow = Graphs.simpleIfElseStructure();
+    
+    Traversal<Node<Integer>> traversal = Traversal.add(flow.endNode())
+        .and(flow.node("next"))
+        .and(flow.node("join"))
+        .inAnyOrder(
+            flow.node("else")
+            .and(flow.node("then"))
+            .period())
+        .and(flow.node("branch"))
+        .and(flow.startNode());
+    
+    traverseAndExpect(flow.startNode(), traversal);
+  }
+  
+  @Test
+  public void testLoopStructure() {
+    Graph<Integer> flow = Graphs.simpleLoopStruture();
+    
+    Traversal<Node<Integer>> expectedTraversal = Traversal.add(flow.endNode())
+        .inAnyOrder(
+            flow.node("body")
+            .and(flow.node("tail"))
+            .period())
+        .and(flow.node("head"))
+        .and(flow.startNode());
+    
+    traverseAndExpect(flow.startNode(), expectedTraversal);
+  }
+  
+  @Test
+  public void testFisherGraph() {
+    Graph<Integer> flow = Graphs.fisher();
+    
+    Traversal<Node<Integer>> expectedTraversal = 
+        Traversal.add(flow.endNode())
+        .and(flow.node("f"))
+        .and(flow.node("e"))
+        .and(flow.node("d"))
+        .inAnyOrder(
+            flow.node("b")
+            .and(flow.node("c"))
+            .period())
+        .and(flow.node("a"))
+        .and(flow.startNode());
+        ;
+    
+    traverseAndExpect(flow.startNode(), expectedTraversal);
+  }
+
+  @Test
+  public void testBinaryTree() {
+    Graph<Integer> flow = Graphs.simpleBinaryTree();
+    
+    Traversal<Node<Integer>> expectedTraversal = 
+        Traversal.addInAnyOrder(
+            flow.node("1")
+            .and(flow.node("4"))
+            .period())
+        .and(flow.node("5"))
+        .and(flow.node("6"))
+        .and(flow.node("2"))
+        .and(flow.node("3"))
+        .and(flow.startNode());
+        ;
+    
+    traverseAndExpect(flow.startNode(), expectedTraversal);
+  }
+}

--- a/blinky-util/src/test/java/org/spideruci/analysis/statik/controlflow/SpanningTreeTest.java
+++ b/blinky-util/src/test/java/org/spideruci/analysis/statik/controlflow/SpanningTreeTest.java
@@ -1,0 +1,163 @@
+package org.spideruci.analysis.statik.controlflow;
+
+import static org.spideruci.jump.GraphAssertions.*;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.spideruci.jump.Graphs;
+
+public class SpanningTreeTest {
+  
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void shouldThrowExceptionWithNullFlowGraph() {
+    // given
+    Graph<Integer> flowGraph = null;
+    
+    // then
+    thrown.expect(IllegalArgumentException.class);
+    
+    //when
+    Algorithms.getDfsSpanningTree(flowGraph);
+  }
+  
+  @Test
+  public void shouldReturnThrowupWhenFlowGraphIsEmpty() {
+    // given
+    Graph<Integer> flowGraph = Graph.createEmptyGraph();
+    
+    // then
+    thrown.expect(IllegalArgumentException.class);
+    
+    //when
+    Algorithms.getDfsSpanningTree(flowGraph);
+  }
+  
+  @Test
+  public void shouldReturnthrowUpWithNullStartNode() {
+    // given
+    Graph<Integer> flowGraph = Graph.create();
+    
+    // then
+    thrown.expect(IllegalArgumentException.class);
+    
+    //when
+    Algorithms.getDfsSpanningTree(flowGraph);
+  }
+
+  @Test
+  public void endShouldPointToStartInGraphWithNoOtherNodes() {
+    // given
+    Graph<Integer> flowGraph = Graphs.justStartAndEnd();
+    
+    System.out.println(flowGraph);
+    
+    //when
+    Graph<Integer> spanningTree = Algorithms.getDfsSpanningTree(flowGraph);
+    System.out.println("yo");
+    System.out.println(spanningTree);
+    
+    //then
+    assert1pointsTo2(Graph.START, Graph.END, spanningTree);
+  }
+
+  @Test
+  public void testSpanningTreeForSimpleIfStructure() {
+    // given
+    Graph<Integer> flowGraph = Graphs.simpleIfStructure();
+    
+    System.out.println(flowGraph);
+    
+    //when
+    Graph<Integer> spanningTree = Algorithms.getDfsSpanningTree(flowGraph);
+    
+    System.out.println(spanningTree);
+    
+    //then
+    assert1pointsTo2(Graph.START, Graph.END, spanningTree);
+    assert1pointsTo2(Graph.START, "branch", spanningTree);
+    assert1pointsTo2("branch", "then", spanningTree);
+    assert1pointsTo2("branch", "join", spanningTree);
+    assert1pointsTo2("join", "next", spanningTree);
+    // ...and
+    assert1doesNotPointTo2("next", Graph.END, spanningTree);
+    assert1doesNotPointTo2(Graph.START, "join", spanningTree);
+    assert1doesNotPointTo2(Graph.START, "next", spanningTree);
+  }
+  
+  @Test
+  public void testSpanningTreeForSimpleIfElseStructure() {
+    // given
+    Graph<Integer> flowGraph = Graphs.simpleIfElseStructure();
+    
+    System.out.println(flowGraph);
+    
+    //when
+    Graph<Integer> spanningTree = Algorithms.getDfsSpanningTree(flowGraph);
+    
+    System.out.println(spanningTree);
+    
+    //then
+    assert1pointsTo2(Graph.START, Graph.END, spanningTree);
+    assert1pointsTo2(Graph.START, "branch", spanningTree);
+    assert1pointsTo2("branch", "then", spanningTree);
+    assert1pointsTo2("branch", "else", spanningTree);
+    assert1pointsTo2("else", "join", spanningTree);
+    assert1pointsTo2("join", "next", spanningTree);
+    // ...and
+    assert1doesNotPointTo2("branch", "join", spanningTree);
+    assert1doesNotPointTo2("next", Graph.END, spanningTree);
+    assert1doesNotPointTo2(Graph.START, "join", spanningTree);
+    assert1doesNotPointTo2(Graph.START, "next", spanningTree);
+  }
+  
+  @Test
+  public void testForSimpleLoopStructure() {
+    // given
+    Graph<Integer> flowGraph = Graphs.simpleLoopStruture();
+    
+    System.out.println(flowGraph);
+    
+    //when
+    Graph<Integer> spanningTree = Algorithms.getDfsSpanningTree(flowGraph);
+    
+    System.out.println(spanningTree);
+    
+    //then
+    assert1pointsTo2(Graph.START, Graph.END, spanningTree);
+    assert1pointsTo2(Graph.START, "head", spanningTree);
+    assert1pointsTo2("head", "body", spanningTree);
+    assert1pointsTo2("head", "tail", spanningTree);
+    //... and
+    assert1doesNotPointTo2("head", Graph.END, spanningTree);
+    assert1doesNotPointTo2(Graph.START, "tail", spanningTree);
+  }
+  
+  /**
+   * <a href="http://pages.cs.wisc.edu/~fischer/cs701.f08/lectures/Lecture19.4up.pdf">http://pages.cs.wisc.edu/~fischer/cs701.f08/lectures/Lecture19.4up.pdf
+   */
+  @Test
+  public void testSpanningTreeFischerLectureExample() {
+    // given
+    Graph<Integer> flowGraph = Graphs.fisher();
+    
+    System.out.println(flowGraph);
+    
+    //when
+    Graph<Integer> spanningTree = Algorithms.getDfsSpanningTree(flowGraph);
+    
+    //then
+    System.out.println(spanningTree);
+    
+    assert1pointsTo2(Graph.START, "a", spanningTree);
+    assert1pointsTo2("a", "b", spanningTree);
+    assert1pointsTo2("a", "c", spanningTree);
+    assert1pointsTo2("c", "d", spanningTree);
+    assert1pointsTo2("d", "e", spanningTree);
+    assert1pointsTo2("e", "f", spanningTree);
+    assert1pointsTo2("f", Graph.END, spanningTree);
+  }
+}

--- a/blinky-util/src/test/java/org/spideruci/analysis/statik/controlflow/StronglyConnectedComponentsTest.java
+++ b/blinky-util/src/test/java/org/spideruci/analysis/statik/controlflow/StronglyConnectedComponentsTest.java
@@ -1,0 +1,204 @@
+package org.spideruci.analysis.statik.controlflow;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+
+import org.junit.Test;
+import org.spideruci.jump.Graphs;
+
+public class StronglyConnectedComponentsTest {
+
+  private void assesrtNoStronglyConnectedComponents(
+    // given
+    Graph<Integer> flowGraph) {
+    
+    // when
+    HashMap<Node<Integer>, Node<Integer>> leaders = 
+        Algorithms.getStronglyConnectedComponents(flowGraph);
+    
+    // then
+    for(Node<Integer> node : leaders.keySet()) {
+      Node<Integer> leader = leaders.get(node);
+      assertEquals(node, leader);
+    }
+  }
+  
+  public static void assertExpectedAndActualLeadersAreSame(
+      HashMap<Node<Integer>, Node<Integer>> actualLeaders,
+      HashMap<Node<Integer>, Node<Integer>> expectedLeaders) {
+    
+    for(Node<Integer> node : actualLeaders.keySet()) {
+      Node<Integer> actualLeader = actualLeaders.get(node);
+      Node<Integer> expectedLeader = expectedLeaders.get(node);
+      assertEquals("For node: " + node, expectedLeader, actualLeader);
+    }
+  }
+  
+  @Test
+  public void testJustStartAndEnd() {
+    assesrtNoStronglyConnectedComponents(Graphs.justStartAndEnd());
+  }
+
+  @Test
+  public void testIfStructure() {
+    assesrtNoStronglyConnectedComponents(Graphs.simpleIfElseStructure());
+  }
+  
+  @Test
+  public void testBinaryTree() {
+    assesrtNoStronglyConnectedComponents(Graphs.simpleBinaryTree());
+  }
+  
+  @Test
+  public void testIfElseStructure() {
+    assesrtNoStronglyConnectedComponents(Graphs.simpleIfElseStructure());
+  }
+
+  @Test
+  public void testLoopStructure() {
+    // given
+    Graph<Integer> flowGraph = Graphs.simpleLoopStruture();
+    
+    // and
+    HashMap<Node<Integer>, Node<Integer>> expectedLeaders = new HashMap<>();
+    
+    expectedLeaders.put(flowGraph.startNode(), flowGraph.startNode());
+    expectedLeaders.put(flowGraph.node("head"), flowGraph.node("head"));
+    expectedLeaders.put(flowGraph.node("body"), flowGraph.node("head"));
+    expectedLeaders.put(flowGraph.node("tail"), flowGraph.node("tail"));
+    expectedLeaders.put(flowGraph.endNode(), flowGraph.endNode());
+    
+    // when
+    HashMap<Node<Integer>, Node<Integer>> actualLeaders = 
+        Algorithms.getStronglyConnectedComponents(flowGraph);
+    
+    // then
+    assertExpectedAndActualLeadersAreSame(actualLeaders, expectedLeaders);
+  }
+  
+  @Test
+  public void testGraphFromFisher() {
+    // given
+    Graph<Integer> flowGraph = Graphs.fisher();
+    
+    // and
+    HashMap<Node<Integer>, Node<Integer>> expectedLeaders = new HashMap<>();
+    
+    expectedLeaders.put(flowGraph.startNode(), flowGraph.startNode());
+    expectedLeaders.put(flowGraph.node("a"), flowGraph.node("a"));
+    expectedLeaders.put(flowGraph.node("b"), flowGraph.node("b"));
+    expectedLeaders.put(flowGraph.node("c"), flowGraph.node("c"));
+    expectedLeaders.put(flowGraph.node("d"), flowGraph.node("d"));
+    expectedLeaders.put(flowGraph.node("e"), flowGraph.node("e"));
+    expectedLeaders.put(flowGraph.node("f"), flowGraph.node("e"));
+    expectedLeaders.put(flowGraph.endNode(), flowGraph.endNode());
+    
+    // when
+    HashMap<Node<Integer>, Node<Integer>> actualLeaders = 
+        Algorithms.getStronglyConnectedComponents(flowGraph);
+    
+    // then
+    assertExpectedAndActualLeadersAreSame(actualLeaders, expectedLeaders);
+  }
+  
+  @Test
+  public void testBinaryTreeWithBackEdges() {
+    // given
+    Graph<Integer> flowGraph = Graphs.simpleBinaryTree();
+    
+    // and
+    flowGraph.node("1").pointsTo(
+        flowGraph.node("3")
+        .and(flowGraph.node("5"))
+        .and(flowGraph.node("4")));
+    flowGraph.node("6").pointsTo(flowGraph.node("2"));
+    
+    // and
+    HashMap<Node<Integer>, Node<Integer>> expectedLeaders = new HashMap<>();
+    
+    expectedLeaders.put(flowGraph.startNode(), flowGraph.startNode());
+    expectedLeaders.put(flowGraph.node("1"), flowGraph.node("3"));
+    expectedLeaders.put(flowGraph.node("2"), flowGraph.node("2"));
+    expectedLeaders.put(flowGraph.node("3"), flowGraph.node("3"));
+    expectedLeaders.put(flowGraph.node("4"), flowGraph.node("4"));
+    expectedLeaders.put(flowGraph.node("5"), flowGraph.node("3"));
+    expectedLeaders.put(flowGraph.node("6"), flowGraph.node("2"));
+    
+    // when
+    HashMap<Node<Integer>, Node<Integer>> actualLeaders = 
+        Algorithms.getStronglyConnectedComponents(flowGraph);
+    
+    // then
+    assertExpectedAndActualLeadersAreSame(actualLeaders, expectedLeaders);
+  }
+  
+  @Test
+  public void testThreeStronglyConnectedComponents() {
+    // given
+    Graph<Integer> flowGraph = Graphs.threeStronglyConnectedComponents();
+    
+    // and
+    HashMap<Node<Integer>, Node<Integer>> expectedLeaders = new HashMap<>();
+    
+    expectedLeaders.put(flowGraph.startNode(), flowGraph.startNode());
+    expectedLeaders.put(flowGraph.node("1"), flowGraph.node("1"));
+    expectedLeaders.put(flowGraph.node("4"), flowGraph.node("1"));
+    expectedLeaders.put(flowGraph.node("7"), flowGraph.node("1"));
+
+    expectedLeaders.put(flowGraph.node("8"), flowGraph.node("8"));
+    expectedLeaders.put(flowGraph.node("2"), flowGraph.node("8"));
+    expectedLeaders.put(flowGraph.node("5"), flowGraph.node("8"));
+
+    expectedLeaders.put(flowGraph.node("9"), flowGraph.node("9"));
+    expectedLeaders.put(flowGraph.node("3"), flowGraph.node("9"));
+    expectedLeaders.put(flowGraph.node("6"), flowGraph.node("9"));
+    
+    // when
+    HashMap<Node<Integer>, Node<Integer>> actualLeaders = 
+        Algorithms.getStronglyConnectedComponents(flowGraph);
+    
+    // then
+    assertExpectedAndActualLeadersAreSame(actualLeaders, expectedLeaders);
+  }
+  
+  @Test
+  public void testJustStartAndEndWithACycle() {
+    // given
+    Graph<Integer> flowGraph = Graphs.startAndEndWithACycle();
+    
+    // and
+    HashMap<Node<Integer>, Node<Integer>> expectedLeaders = new HashMap<>();
+    
+    expectedLeaders.put(flowGraph.startNode(), flowGraph.startNode());
+    expectedLeaders.put(flowGraph.endNode(), flowGraph.startNode());
+    
+    // when
+    HashMap<Node<Integer>, Node<Integer>> actualLeaders = 
+        Algorithms.getStronglyConnectedComponents(flowGraph);
+    
+    // then
+    assertExpectedAndActualLeadersAreSame(actualLeaders, expectedLeaders);
+  }
+  
+  @Test
+  public void testThreeNodesWithOneCycle() {
+    // given
+    Graph<Integer> flowGraph = Graphs.threeNodesWithACycle();
+    
+    // and
+    HashMap<Node<Integer>, Node<Integer>> expectedLeaders = new HashMap<>();
+    
+    expectedLeaders.put(flowGraph.startNode(), flowGraph.startNode());
+    expectedLeaders.put(flowGraph.node("node"), flowGraph.startNode());
+    expectedLeaders.put(flowGraph.endNode(), flowGraph.startNode());
+    
+    // when
+    HashMap<Node<Integer>, Node<Integer>> actualLeaders = 
+        Algorithms.getStronglyConnectedComponents(flowGraph);
+    
+    // then
+    assertExpectedAndActualLeadersAreSame(actualLeaders, expectedLeaders);
+  }
+
+}

--- a/blinky-util/src/test/java/org/spideruci/jump/GraphAssertions.java
+++ b/blinky-util/src/test/java/org/spideruci/jump/GraphAssertions.java
@@ -1,0 +1,25 @@
+package org.spideruci.jump;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.spideruci.analysis.statik.controlflow.Graph;
+import org.spideruci.analysis.statik.controlflow.Node;
+
+public class GraphAssertions {
+  
+  public static <T> void assert1pointsTo2(String one, String two, Graph<T> graph) {
+    assertTrue("Expceted: " + one +  "--->" + two, 
+        graph.node(one).pointsTo().contains(graph.node(two)));
+  }
+  
+  public static <T> void assert1doesNotPointTo2(String one, String two, Graph<T> graph) {
+    assertFalse("Expceted: " + one +  "-/->" + two,
+        graph.node(one).pointsTo().contains(graph.node(two)));
+  }
+  
+  public static <T> void assertNodeIsSolitary(Node<T> node) {
+    assertTrue(node.isPointedByNone() && node.pointsToNone());
+  }
+
+}

--- a/blinky-util/src/test/java/org/spideruci/jump/Graphs.java
+++ b/blinky-util/src/test/java/org/spideruci/jump/Graphs.java
@@ -1,0 +1,163 @@
+package org.spideruci.jump;
+
+import org.spideruci.analysis.statik.controlflow.Graph;
+import org.spideruci.analysis.statik.controlflow.Node;
+
+public class Graphs {
+  
+  public static Graph<Integer> justStartAndEnd() {
+    Graph<Integer> flowGraph = Graph.create();
+    flowGraph.startNode().pointsTo(flowGraph.endNode());
+    return flowGraph;
+  }
+  
+  public static Graph<Integer> startAndEndWithACycle() {
+    Graph<Integer> flowGraph = Graphs.justStartAndEnd();
+    return flowGraph.endPointsTo(flowGraph.startNode());
+  }
+  
+  public static Graph<Integer> threeNodesWithACycle() {
+    Graph<Integer> flowGraph = Graph.create();
+    
+    Node<Integer> node = Node.create("node", flowGraph);
+    flowGraph.nowHas(node);
+    flowGraph.startPointsTo(node.pointsTo(flowGraph.endNode()));
+    flowGraph.endPointsTo(flowGraph.startNode());
+    
+    return flowGraph;
+  }
+  
+  public static Graph<Integer> simpleIfStructure() {
+    Graph<Integer> flowGraph = Graph.create();
+    flowGraph.startNode().pointsTo(flowGraph.endNode());
+    
+    Node<Integer> branch = Node.create("branch", flowGraph);
+    Node<Integer> then = Node.create("then", flowGraph);
+    Node<Integer> join = Node.create("join", flowGraph);
+    Node<Integer> next = Node.create("next", flowGraph);
+    flowGraph.nowHas(branch.and(then).and(join).and(next));
+    
+    flowGraph.startNode().pointsTo(branch);
+    branch.pointsTo(then.and(join));
+    then.pointsTo(join);
+    join.pointsTo(next);
+    next.pointsTo(flowGraph.endNode());
+    
+    return flowGraph;
+  }
+  
+  public static Graph<Integer> simpleIfElseStructure() {
+    Graph<Integer> flowGraph = Graph.create();
+    flowGraph.startNode().pointsTo(flowGraph.endNode());
+    
+    Node<Integer> branch = Node.create("branch", flowGraph);
+    Node<Integer> then = Node.create("then", flowGraph);
+    Node<Integer> elze = Node.create("else", flowGraph);
+    Node<Integer> join = Node.create("join", flowGraph);
+    Node<Integer> next = Node.create("next", flowGraph);
+    flowGraph.nowHas(branch.and(then).and(elze).and(join).and(next));
+    
+    flowGraph.startNode().pointsTo(branch);
+    branch.pointsTo(then.and(elze));
+    then.pointsTo(join);
+    elze.pointsTo(join);
+    join.pointsTo(next);
+    next.pointsTo(flowGraph.endNode());
+    
+    return flowGraph;
+  }
+  
+  public static Graph<Integer> simpleLoopStruture() {
+    Graph<Integer> flowGraph = Graph.create();
+    flowGraph.startNode().pointsTo(flowGraph.endNode());
+    
+    Node<Integer> head = Node.create("head", flowGraph);
+    Node<Integer> body = Node.create("body", flowGraph);
+    Node<Integer> tail = Node.create("tail", flowGraph);
+    flowGraph.nowHas(head.and(body).and(tail));
+    
+    flowGraph.startNode().pointsTo(head);
+    head.pointsTo(body.and(tail));
+    body.pointsTo(head);
+    tail.pointsTo(flowGraph.endNode());
+    
+    return flowGraph;
+  }
+  
+  /**
+   * <a href="http://pages.cs.wisc.edu/~fischer/cs701.f08/lectures/Lecture19.4up.pdf">http://pages.cs.wisc.edu/~fischer/cs701.f08/lectures/Lecture19.4up.pdf
+   */
+  public static Graph<Integer> fisher() {
+    Graph<Integer> flowGraph = Graph.create("fischer");
+    
+    Node<Integer> a = Node.create("a", flowGraph);
+    Node<Integer> b = Node.create("b", flowGraph);
+    Node<Integer> c = Node.create("c", flowGraph);
+    Node<Integer> d = Node.create("d", flowGraph);
+    Node<Integer> e = Node.create("e", flowGraph);
+    Node<Integer> f = Node.create("f", flowGraph);
+    flowGraph.nowHas(a.and(b).and(c).and(d).and(e).and(f));
+    
+    flowGraph.startNode().pointsTo(a);
+    a.pointsTo(b.and(c));
+    b.pointsTo(d);
+    c.pointsTo(d);
+    d.pointsTo(e);
+    e.pointsTo(f);
+    f.pointsTo(flowGraph.endNode().and(e));
+    return flowGraph;
+  }
+  
+  public static Graph<Integer> simpleBinaryTree() {
+    Graph<Integer> flowGraph = Graph.create("binary");
+    
+    Node<Integer> n1 = Node.create("1", flowGraph);
+    Node<Integer> n2 = Node.create("2", flowGraph);
+    Node<Integer> n3 = Node.create("3", flowGraph);
+    Node<Integer> n4 = Node.create("4", flowGraph);
+    Node<Integer> n5 = Node.create("5", flowGraph);
+    Node<Integer> n6 = Node.create("6", flowGraph);
+    
+    flowGraph.nowHas(n1.and(n2).and(n3).and(n4).and(n5).and(n6));
+    
+    flowGraph.startPointsTo(n3);
+    n3.pointsTo(n5.and(n2));
+    n5.pointsTo(n1.and(n4));
+    n2.pointsTo(n6);
+    
+    return flowGraph;
+    
+  }
+
+  public static Graph<Integer> threeStronglyConnectedComponents() {
+    Graph<Integer> flowGraph = Graph.create("3scc");
+    
+    Node<Integer> n1 = Node.create("1", flowGraph);
+    Node<Integer> n2 = Node.create("2", flowGraph);
+    Node<Integer> n3 = Node.create("3", flowGraph);
+    Node<Integer> n4 = Node.create("4", flowGraph);
+    Node<Integer> n5 = Node.create("5", flowGraph);
+    Node<Integer> n6 = Node.create("6", flowGraph);
+    Node<Integer> n7 = Node.create("7", flowGraph);
+    Node<Integer> n8 = Node.create("8", flowGraph);
+    Node<Integer> n9 = Node.create("9", flowGraph);
+    
+    flowGraph.nowHas(n1.and(n2).and(n3).and(n4).and(n5).and(n6).and(n7).and(n8).and(n9));
+    
+    flowGraph.startPointsTo(n1);
+    
+    n1.pointsTo(n7);
+    n4.pointsTo(n1);
+    n7.pointsTo(n4.and(n9));
+    n9.pointsTo(n6);
+    n3.pointsTo(n9);
+    n6.pointsTo(n3.and(n8));
+    n8.pointsTo(n2);
+    n2.pointsTo(n5);
+    n5.pointsTo(n8);
+    
+    
+    return flowGraph;
+  }
+
+}

--- a/blinky-util/src/test/java/org/spideruci/jump/Traversal.java
+++ b/blinky-util/src/test/java/org/spideruci/jump/Traversal.java
@@ -1,0 +1,128 @@
+package org.spideruci.jump;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+public class Traversal<T> {
+  
+  private ArrayList<Step<T>> traversal = new ArrayList<>();
+  
+  public static <T> Traversal<T> add(T item) {
+    Traversal<T> t = new Traversal<>();
+    t.and(item);
+    return t;
+  }
+  
+  public static <T> Traversal<T> addInAnyOrder(ArrayList<T> items) {
+    Traversal<T> t = new Traversal<>();
+    t.inAnyOrder(items);
+    return t;
+  }
+  
+  public Traversal<T> and(T item) {
+    Step<T> step = Step.step(item);
+    traversal.add(step);
+    return this;
+  }
+  
+  public Traversal<T> inAnyOrder(ArrayList<T> items) {
+    Step<T> step = Step.steps(items);
+    traversal.add(step);
+    return this;
+  }
+  
+  @Override
+  public String toString() {
+    return this.traversal.toString();
+  }
+  
+  public void compareWith(ArrayList<T> actualTraversal) {
+    
+    for(int i = 0, j = 0; i < actualTraversal.size();) {
+      
+      if(j >= traversal.size()) {
+        throw new RuntimeException(
+            String.format("actual traversal: %s; expected traversal: %s", 
+                actualTraversal.toString(), 
+                this.toString()));
+      }
+      Step<T> step = traversal.get(j); 
+      if(step.isKnown()) {
+        T actualItem = actualTraversal.get(i);
+        assertEquals("@position " + i, step.item, actualItem);
+        i += 1;
+      } else {
+        ArrayList<T> itemsInAnyOrder = step.items;
+        
+        for(int k = i; k < i + itemsInAnyOrder.size(); k += 1) {
+          T actualItem = actualTraversal.get(k);
+          String errMsg = String.format(
+              "expected actual item -- %s -- to be one of the following: %s", 
+              actualItem, itemsInAnyOrder);
+          assertTrue(errMsg, itemsInAnyOrder.contains(actualItem));
+        }
+        
+        i += itemsInAnyOrder.size();
+      }
+      
+      j += 1;
+    }
+  }
+  
+  public static class Step<T> {
+     private final T item;
+     private final ArrayList<T> items;
+     
+     
+     public static <T> Step<T> steps(T[] items) {
+       Step<T> step = new Step<>(Collections.emptyList());
+       
+       for(T item : items) {
+         step.items.add(item);
+       }
+       
+       return step;
+     }
+     
+     public static <T> Step<T> steps(Collection<T> items) {
+       return new Step<>(items);
+     }
+     
+     public static <T> Step<T> step(T item) {
+       return new Step<>(item);
+     }
+     
+     private Step(T item) {
+       this.item = item;
+       this.items = null;
+     }
+     
+     private Step(Collection<T> items) {
+       this.item = null;
+       
+       this.items = new ArrayList<>();
+       for(T it : items) {
+         this.items.add(it);
+       }
+
+     }
+     
+     public boolean isKnown() {
+       return this.item != null;
+     }
+     
+     @Override
+     public String toString() {
+       if(isKnown()) {
+         return this.item.toString();
+       } else {
+         return this.items.toString();
+       }
+     }
+  }
+
+}


### PR DESCRIPTION
Fixing #44. Two stage change (copying notes from commit notes):

## Change to Blinky Util
- Jump was a separate project that I created to factor out some
  grpah related utilites around static analysis. I am now adding
  these utlities to Util so that Blinky does not depend on yet
  another project outside gh/spideruci/blinky.
- I had to modify the compiler setting for Util from 1.7 -> 1.8,
  since I was using a few lambdas in Jump. Added a different task
  to track the work needed to upgrade Blinky to Java 8: see #45 
- Testing: Build passing on the following commands:
  `mvn clean && mvn compile && mvn test`

## Change to Blinky Statik
Migrating from Jump to Blinky Util for all Graph related utilites
that were earlier housed in Jump (see gh/vijaykrishna/jump).

Testing: Build passing on the following commands:
mvn clean -P statik
mvn compile -P statik
mvn test -P statik