### PR TITLE
Added support for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,7 @@ jdk:
 before_install: ./scripts/before_install.sh
 
 script: mvn clean verify -P full
+
+cache:
+    directories:
+    - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: java
+
+jdk: 
+- oraclejdk8
+
+before_install:
+- git clone https://github.com/inf295uci-2015/primitive-hamcrest.git  
+- cd primitive-hamcrest  
+- mvn install
+- cd ..
+- git clone https://github.com/spideruci/tacoco.git
+- cd tacoco
+- mvn install
+- cd ..
+
+after_success:
+- mvn clean test -P full

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,6 @@ language: java
 jdk: 
 - oraclejdk8
 
-before_install:
-- git clone https://github.com/inf295uci-2015/primitive-hamcrest.git  
-- cd primitive-hamcrest  
-- mvn install
-- cd ..
-- git clone https://github.com/spideruci/tacoco.git
-- cd tacoco
-- mvn install
-- cd ..
+before_install: ./scripts/before_install.sh
 
-after_success:
-- mvn clean test -P full
+script: mvn clean verify -P full

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 <img src="https://cloud.githubusercontent.com/assets/1355460/15376410/b6224b0a-1d09-11e6-9b18-77a8d03eb03d.png" width="250">
 # Blinky: Java Code Instrumenter and Execution Tracer
 
+![](https://travis-ci.org/spideruci/blinky.svg?branch=master)
+
 Check out the project wiki for more information: https://github.com/spideruci/blinky/wiki

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="https://cloud.githubusercontent.com/assets/1355460/15376410/b6224b0a-1d09-11e6-9b18-77a8d03eb03d.png" width="250">
 # Blinky: Java Code Instrumenter and Execution Tracer
 
-![](https://travis-ci.org/spideruci/blinky.svg?branch=master)
+[![](https://travis-ci.org/spideruci/blinky.svg?branch=master)](https://travis-ci.org/spideruci/blinky)
 
 Check out the project wiki for more information: https://github.com/spideruci/blinky/wiki

--- a/scripts/before_install.sh
+++ b/scripts/before_install.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -ev
+
+git clone https://github.com/inf295uci-2015/primitive-hamcrest.git  
+cd primitive-hamcrest  
+mvn install
+cd ..
+git clone https://github.com/spideruci/tacoco.git
+cd tacoco
+mvn install
+cd ..


### PR DESCRIPTION
Added support for Travis-CI at the moment the building process is relative slow (±2 minutes), so I think I should add caching to it, to cache Tacoco and the Hamcrest dependencies. However, I wanted to open a discussion about what other checks should be placed in the integration process (style checkers for example)?