### PR TITLE
Travis diagnostic fix

### DIFF
--- a/blinky-diagnostics/scripts/diagnose
+++ b/blinky-diagnostics/scripts/diagnose
@@ -50,14 +50,21 @@ for MAIN in "Namaste" \
   "SummaryLib 4" \
   "SummaryLib 5" \
   "SummaryLib 6" \
-  "styleEx.noCommitment.NoCommitment"; do
+  "styleEx.CandyFactory" \
+  "styleEx.CookBook" \
+  "styleEx.DeclaredIntentions" \
+  "styleEx.Hollywood" \
+  "styleEx.Quarantine" \
+  "styleEx.TheOne"; do
   
   
   SUBJECT=${BOLD}"$MAIN"${NORMAL}
   
   echo $SUBJECT
-  echo "🏃 running $SUBJECT with java"
-  java -cp .:$DIAGNOSTICS_JAR "$SUBJECTS_PKG."$MAIN
+  echo -ne "🏃 running $SUBJECT with java"
+  systime="$(TIMEFORMAT='%S';time ( java -cp .:$DIAGNOSTICS_JAR "$SUBJECTS_PKG."$MAIN > /dev/null 2>&1 ) 2>&1 1>/dev/null )"
+  echo " ==> $systime sec"
+  
   echo "🏃 running $SUBJECT with 🌟 blinky"
   for CONFIG in ${CONFIGS[@]}; do
     echo -ne "👉 with configuration: $CONFIG"

--- a/blinky-diagnostics/scripts/diagnose
+++ b/blinky-diagnostics/scripts/diagnose
@@ -60,9 +60,9 @@ for MAIN in "Namaste" \
   java -cp .:$DIAGNOSTICS_JAR "$SUBJECTS_PKG."$MAIN
   echo "🏃 running $SUBJECT with 🌟 blinky"
   for CONFIG in ${CONFIGS[@]}; do
-    echo "👉 with configuration: $CONFIG"
-    
-    java $BLINKY$CONFIG -cp .:$DIAGNOSTICS_JAR "$SUBJECTS_PKG."$MAIN > /dev/null 2>&1
+    echo -ne "👉 with configuration: $CONFIG"
+    systime="$(TIMEFORMAT='%S';time ( java $BLINKY$CONFIG -cp .:$DIAGNOSTICS_JAR "$SUBJECTS_PKG."$MAIN > /dev/null 2>&1 ) 2>&1 1>/dev/null )"
+    echo " ==> $systime sec"
   done
 done
 
@@ -78,5 +78,5 @@ function check {
   done
 }
 
-# check traces
-# check traces-full
+#check traces
+#check traces-full

--- a/blinky-diagnostics/scripts/diagnose
+++ b/blinky-diagnostics/scripts/diagnose
@@ -50,23 +50,6 @@ for MAIN in "Namaste" \
   "SummaryLib 4" \
   "SummaryLib 5" \
   "SummaryLib 6" \
-  "styleEx.BulletinBoard" \
-  "styleEx.CandyFactory" \
-  "styleEx.CodeGolf" \
-  "styleEx.Constructivist" \
-  "styleEx.CookBook" \
-  "styleEx.DeclaredIntentions" \
-  "styleEx.Hollywood" \
-  "styleEx.HollywoodWordsWithZ" \
-  "styleEx.InfiniteMirror" \
-  "styleEx.KickYourTeammateForward" \
-  "styleEx.LazyRivers" \
-  "styleEx.PersistentTablesReader" \
-  "styleEx.Quarantine" \
-  "styleEx.Spreadsheet" \
-  "styleEx.Tantrum" \
-  "styleEx.TermFrequency" \
-  "styleEx.TheOne" \
   "styleEx.noCommitment.NoCommitment"; do
   
   
@@ -79,7 +62,7 @@ for MAIN in "Namaste" \
   for CONFIG in ${CONFIGS[@]}; do
     echo "👉 with configuration: $CONFIG"
     
-    #java $BLINKY$CONFIG -cp .:$DIAGNOSTICS_JAR "$SUBJECTS_PKG."$MAIN > /dev/null 2>&1
+    java $BLINKY$CONFIG -cp .:$DIAGNOSTICS_JAR "$SUBJECTS_PKG."$MAIN > /dev/null 2>&1
   done
 done
 
@@ -95,5 +78,5 @@ function check {
   done
 }
 
-#check traces
-#check traces-full
+# check traces
+# check traces-full


### PR DESCRIPTION
The diagnostic script contained an error where the blinky command was commented out. This has been fixed, however, running all examples with all configuration takes long and will not be feasible to run on travis, so we limit it to a smaller amount of programs.

Also after finishing running with a configuration we check how long it took to run the configuration.