### PR TITLE
Variable XOR-ed with itself in test

### DIFF
--- a/blinky-config/src/test/java/org/spideruci/analysis/config/definer/TestConfigFieldsDefiner.java
+++ b/blinky-config/src/test/java/org/spideruci/analysis/config/definer/TestConfigFieldsDefiner.java
@@ -130,7 +130,7 @@ public class TestConfigFieldsDefiner {
       
       assertEquals(isFieldExpectedToBeDefined, isFieldActuallyDefined);
       
-      if(isFieldExpectedToBeDefined ^ isFieldExpectedToBeDefined) { // different
+      if(isFieldExpectedToBeDefined ^ isFieldActuallyDefined) { // different
         System.out.print(isFieldExpectedToBeDefined ? "expecting defined; " : "expecting not defined; ");
         System.out.println(isFieldActuallyDefined ? "actually defined" : "actually not defined");
       } else {


### PR DESCRIPTION
I think this is a bug. I assume the variable Fixed a bug that a variable was xor-ed with itself instead of a other variable. The current line of code: ```isFieldExpectedToBeDefined ^ isFieldExpectedToBeDefined```, always evaluates to false.

xor
0 0 | 0
0 1 | 1
1 0 | 1
1 1 | 0