### PR TITLE
Update dependency ASM-debug-all 5.0 to needed modules of ASM 6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,23 @@
  <dependencies>
   <dependency>
    <groupId>org.ow2.asm</groupId>
-   <artifactId>asm-debug-all</artifactId>
-   <version>5.0</version>
+   <artifactId>asm</artifactId>
+   <version>6.2</version>
+  </dependency>
+  <dependency>
+   <groupId>org.ow2.asm</groupId>
+   <artifactId>asm-tree</artifactId>
+   <version>6.2</version>
+  </dependency>
+  <dependency>
+   <groupId>org.ow2.asm</groupId>
+   <artifactId>asm-util</artifactId>
+   <version>6.2</version>
+  </dependency>
+  <dependency>
+   <groupId>org.ow2.asm</groupId>
+   <artifactId>asm-commons</artifactId>
+   <version>6.2</version>
   </dependency>
   <dependency>
    <groupId>junit</groupId>


### PR DESCRIPTION
Problem: blinky was not able to run on project compiled with java 9 or higher (fixes Issue #51  )

Solution: Updated the ASM dependency from 5.0 to the needed modules of ASM version 6.2.