### PR TITLE
Update travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,27 @@
 language: java
 
-jdk: 
-- oraclejdk8
+matrix:
+    include:
+    - name: java8
+      jdk: openjdk8
+      dist: xenial
 
+    - name: java11
+      jdk: openjdk11
+      dist: bionic
+
+    - name: java13
+      jdk: openjdk13
+      dist: bionic
+    
+    allow_failures:
+    - name: java11
+      jdk: openjdk11
+      dist: bionic
+
+    - name: java13
+      jdk: openjdk13
+      dist: bionic
 before_install: ./scripts/before_install.sh
 
 script: mvn clean verify -P full


### PR DESCRIPTION
Travis ci will at points update what is the default container used. However, because we rely on those containers having a version of java installed it is maybe a good idea to explicitly state which one we are using. So I have changed the travis.yml in two ways:
1. Set an explicit distribution for openjdk8, so when the default is changed by travis it doesn't impact the build.
2. Added openjdk11 and 13 configuration that are allowed to fail for now

The last was added, so we can start working on getting blinky ready for future java versions. 