### PR TITLE
Updated the pom.xml 

### DIFF
--- a/blinky-config/pom.xml
+++ b/blinky-config/pom.xml
@@ -17,10 +17,6 @@
 
   <url>https://github.com/spideruci/blinky</url>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
-
   <dependencies>
     <dependency>
     <groupId>com.esotericsoftware.yamlbeans</groupId>

--- a/blinky-core/pom.xml
+++ b/blinky-core/pom.xml
@@ -15,12 +15,6 @@
  <name>Blinky Core</name>
  <url>https://github.com/spideruci/blinky</url>
 
- <properties>
-  <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  <maven.compiler.source>1.7</maven.compiler.source>
-  <maven.compiler.target>1.7</maven.compiler.target>
- </properties>
-
  <build>
   <sourceDirectory>src</sourceDirectory>
   <testSourceDirectory>test</testSourceDirectory>

--- a/blinky-diagnostics/pom.xml
+++ b/blinky-diagnostics/pom.xml
@@ -16,14 +16,6 @@
  <name>Blinky Diagnostics</name>
  <url>https://github.com/spideruci/blinky</url>
 
-
-
- <properties>
-  <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  <maven.compiler.source>1.8</maven.compiler.source>
-  <maven.compiler.target>1.8</maven.compiler.target>
- </properties>
-
  <dependencies>
   <dependency>
    <groupId>org.xerial</groupId>

--- a/blinky-statik/pom.xml
+++ b/blinky-statik/pom.xml
@@ -14,9 +14,6 @@
   <name>Blinky Statik</name>
   <url>https://github.com/spideruci/blinky</url>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>org.spideruci.analysis.util</groupId>

--- a/blinky-tacoco/pom.xml
+++ b/blinky-tacoco/pom.xml
@@ -14,10 +14,6 @@
  <name>Blinky Tacoco</name>
  <url>https://github.com/spideruci/blinky</url>
 
- <properties>
-  <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
- </properties>
-
  <build>
   <resources>
     <resource>

--- a/blinky-trace-manager/pom.xml
+++ b/blinky-trace-manager/pom.xml
@@ -15,20 +15,14 @@
  <name>Blinky Trace Manager</name>
  <url>https://github.com/spideruci/blinky</url>
 
- <properties>
-  <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  <maven.compiler.source>1.7</maven.compiler.source>
-  <maven.compiler.target>1.7</maven.compiler.target>
- </properties>
-
  <build>
   <plugins>
    <plugin>
     <artifactId>maven-compiler-plugin</artifactId>
     <version>3.1</version>
     <configuration>
-     <source>1.7</source>
-     <target>1.7</target>
+     <source>${maven.compiler.source}</source>
+     <target>${maven.compiler.target}</target>
     </configuration>
    </plugin>
   </plugins>

--- a/blinky-util/pom.xml
+++ b/blinky-util/pom.xml
@@ -14,19 +14,14 @@
  <name>Blinky Util</name>
  <url>https://github.com/spideruci/blinky</url>
 
-
- <properties>
-  <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
- </properties>
-
  <build>
   <plugins>
    <plugin>
     <artifactId>maven-compiler-plugin</artifactId>
     <version>3.1</version>
     <configuration>
-     <source>1.8</source>
-     <target>1.8</target>
+     <source>${maven.compiler.source}</source>
+     <target>${maven.compiler.source}</target>
     </configuration>
    </plugin>
   </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,9 @@
  <url>https://github.com/spideruci/blinky</url>
 
  <properties>
-  <maven.compiler.source>1.7</maven.compiler.source>
-  <maven.compiler.target>1.7</maven.compiler.target>
+  <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  <maven.compiler.source>1.8</maven.compiler.source>
+  <maven.compiler.target>1.8</maven.compiler.target>
  </properties>
 
  <packaging>pom</packaging>
@@ -26,13 +27,13 @@
   <dependency>
    <groupId>junit</groupId>
    <artifactId>junit</artifactId>
-   <version>4.12</version>
+   <version>4.13</version>
    <scope>test</scope>
   </dependency>
   <dependency>
    <groupId>org.mockito</groupId>
    <artifactId>mockito-core</artifactId>
-   <version>2.0.31-beta</version>
+   <version>2.28.2</version>
    <scope>test</scope>
   </dependency>
  </dependencies>


### PR DESCRIPTION
This pull requests contained two changes:
- Moved all shared properties to the parent pom (i.e., UTF-8 and source and target jdk)
- Updated dependencies (junit/mockito) to the latest versions of the same major release (respectively, 4.13 and 2.28.2).

When merged we can close #45. 